### PR TITLE
Dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Change Log
 
+### 0.4.4
+
+- [+] 添加了 typescript 如何使用 form-render 的说明文档
+- [+] 为了属性的规范化，列表组件添加了`"ui:options"`/`"buttons"` 属性, buttons 的 callback 可调用参数 value 和 onChange，便于直接操作当前数组，详见文档
+- [!] json 里书写函数表达式现在推荐使用 `"{{...}}"` 的方式，同时继续兼容 `"@..."`
+- [!] 大幅更新了文档，添加了 TypeScript 的支持方案，form-render 后期规划，同时更新了初始 demo 的搭建代码
+- [!] 只读模式下，UI 统一使用 disabled 的状态展示
+- [!] 解决了有时`"ui:extraButtons"`不能正常展示的 bug
+- [!] 颜色组件现在会校验 hex 值，并提示用户添加“#”（不再允许输入六位 hex 值但不输入#）
+- [!] `propsSchema` 的文档补全了所有组件的常用字段
+- [!] 在线 demo 添加了标签宽度控制（“左右排列”时有效）
+  <img src="https://img.alicdn.com/tfs/TB1h1ZGrQT2gK0jSZFkXXcIQFXa-816-476.jpg" width="400" />
+
 ### 0.4.3
 
 - [!] 修复了一个文件名在 macOS 大小写不敏感造成的 bug

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,19 @@
 
 ### 0.4.4
 
-- [+] 添加了 typescript 如何使用 form-render 的说明文档
+- [+] 发布了 schema 书写利器 `form-render snippets`（vscode 插件），在 vscode 商店中搜索“formrender”
+  <img src="https://img.alicdn.com/tfs/TB1VIfBqWL7gK0jSZFBXXXZZpXa-1976-1464.png" width="400" />
+- [+] 添加了 typescript 如何使用 form-render 的说明文档 ([#46](https://github.com/alibaba/form-render/issues/46)/[#44](https://github.com/alibaba/form-render/issues/44))
 - [+] 为了属性的规范化，列表组件添加了`"ui:options"`/`"buttons"` 属性, buttons 的 callback 可调用参数 value 和 onChange，便于直接操作当前数组，详见文档
 - [!] json 里书写函数表达式现在推荐使用 `"{{...}}"` 的方式，同时继续兼容 `"@..."`
-- [!] 大幅更新了文档，添加了 TypeScript 的支持方案，form-render 后期规划，同时更新了初始 demo 的搭建代码
+- [!] 大幅更新了文档，ts 支持，form-render 后期规划，同时更新了初始 demo 的搭建代码
 - [!] 只读模式下，UI 统一使用 disabled 的状态展示
 - [!] 解决了有时`"ui:extraButtons"`不能正常展示的 bug
-- [!] 颜色组件现在会校验 hex 值，并提示用户添加“#”（不再允许输入六位 hex 值但不输入#）
+- [!] 颜色组件现在会校验 hex 值，并提示用户添加“#”（不再允许输入六位 hex 值但不输入#）（[#48](https://github.com/alibaba/form-render/issues/48)）
 - [!] `propsSchema` 的文档补全了所有组件的常用字段
 - [!] 在线 demo 添加了标签宽度控制（“左右排列”时有效）
   <img src="https://img.alicdn.com/tfs/TB1h1ZGrQT2gK0jSZFkXXcIQFXa-816-476.jpg" width="400" />
+- [!] fusion 主题下标题、输入框的样式修复
 
 ### 0.4.3
 

--- a/README.md
+++ b/README.md
@@ -33,75 +33,75 @@
 ## 安装
 
 ```sh
-npm i form-render -S
+npm i form-render
+# or
+yarn add form-render
 ```
 
 ## 快速使用
 
-```react
-import React from "react";
-import ReactDOM from "react-dom";
+```js
+import React, { useState } from 'react';
+import ReactDOM from 'react-dom';
 // 使用 Ant Design 体系
-import FormRender from "form-render/lib/antd";
+import FormRender from 'form-render/lib/antd';
 
 // 使用 Fusion Design 体系
 // import "@alifd/next/dist/next.min.css";
 // import FormRender from "form-render/lib/fusion";
 
-// propsSchema 使用标准的 JSON Schema 来描述表单结构
-const propSchema = {
-  type: "object",
+const propsSchema = {
+  type: 'object',
   properties: {
-    dateDemo: {
-      title: "时间",
-      type: "string"
-    }
-  }
+    string: {
+      title: '字符串',
+      type: 'string',
+      'ui:width': '50%', // uiSchema 可以合并到 propsSchema 中
+    },
+    select: {
+      title: '单选',
+      type: 'string',
+      enum: ['a', 'b', 'c'],
+    },
+  },
 };
 
-// uiSchema 可以增强展示类型的丰富性，如时间组件
+// 也可以选择单独使用 uiSchema 字段分开定义每个字段的 ui 属性
 const uiSchema = {
-  dateDemo: {
-    "ui:widget": "date"
-  }
+  select: {
+    'ui:width': '50%',
+  },
 };
 
-class App extends React.Component {
-  constructor() {
-    super();
-    this.state = {
-      formData: {}
-    };
-  }
+function Demo() {
+  const [formData, setData] = useState({});
+  const [valid, setValid] = useState([]);
 
-  // 数据变化回调
-  onChange = value => {
-    this.setState({
-      formData: value
-    });
+  const onSubmit = () => {
+    // valid 是校验判断的数组，valid 长度为 0 代表校验全部通过
+    if (valid.length > 0) {
+      alert(`校验未通过字段：${valid.toString()}`);
+    } else {
+      alert(JSON.stringify(formData, null, 2));
+    }
   };
 
-  // 数据格式校验回调
-  onValidate = list => {
-    console.log(list);
-  };
-
-  render() {
-    const { formData } = this.state;
-    return (
+  return (
+    <div style={{ padding: 60 }}>
       <FormRender
-        propsSchema={propSchema}
+        propsSchema={propsSchema}
         uiSchema={uiSchema}
         formData={formData}
-        onChange={this.onChange}
-        onValidate={this.onValidate}
+        onChange={setData}
+        onValidate={setValid}
       />
-    );
-  }
+      <button onClick={onSubmit}>提交</button>
+    </div>
+  );
 }
 
-const rootElement = document.getElementById("root");
-ReactDOM.render(<App />, rootElement);
+const rootElement = document.getElementById('root');
+ReactDOM.render(<Demo />, rootElement);
 ```
 
 ### API
@@ -124,14 +124,22 @@ ReactDOM.render(<App />, rootElement);
 
 ### 不常用 API
 
-| Prop               |    Type     | Required | Default  |                    Description                    |
-| ------------------ | :---------: | :------: | :------: | :-----------------------------------------------: |
-| **`column`**       |  `Number`   |   `1`    |   `N`    | 整体布局 1 排 N，局部的 1 排 N 一般使用`ui:width` |
-| **`showValidate`** |  `Boolean`  |   `N`    |  `true`  |                 是否展示校验信息                  |
-| **`showDescIcon`** |  `Boolean`  |   `N`    | `false`  |     是否将文字形式说明显示成描述 tooltip 形式     |
-| **`widgets`**      |  `Object`   |   `N`    |   `{}`   |                    自定义组件                     |
-| **`mapping`**      |  `Object`   |   `N`    |   `{}`   |              用于修改默认组件映射表               |
-| **`FieldUI`**      | `Component` |   `N`    | 内置组件 |     用于自定义整个元素的样式（标签、结构等）      |
+| Prop               |   Type    | Required | Default |                    Description                    |
+| ------------------ | :-------: | :------: | :-----: | :-----------------------------------------------: |
+| **`column`**       | `Number`  |   `1`    |   `N`   | 整体布局 1 排 N，局部的 1 排 N 一般使用`ui:width` |
+| **`showValidate`** | `Boolean` |   `N`    | `true`  |                 是否展示校验信息                  |
+| **`showDescIcon`** | `Boolean` |   `N`    | `false` |     是否将文字形式说明显示成描述 tooltip 形式     |
+| **`widgets`**      | `Object`  |   `N`    |  `{}`   |                    自定义组件                     |
+| **`mapping`**      | `Object`  |   `N`    |  `{}`   |              用于修改默认组件映射表               |
+
+## 快速书写 schema
+
+快速准确书写 schema 一直是使用者的痛点。为此我们准备了 schema 书写利器： `form-render snippets`（vscode 插件），在 vscode 商店输入 ‘formrender’ 搜索：
+![](https://img.alicdn.com/tfs/TB1VIfBqWL7gK0jSZFBXXXZZpXa-1976-1464.png)
+
+## 支持 TypeScript
+
+详见[如何在 TypeScript 项目中使用](docs/typescript)
 
 ## 支持 Ant Design 自定义主题不被覆盖
 
@@ -164,8 +172,12 @@ FormRender 底层引擎用原生 JS 来实现，通过解析 JSON Schema 配置�
 ```shell
 > git clone https://github.com/alibaba/form-render.git
 > npm i
-> npm run start
+> npm start
 ```
+
+## 后期规划
+
+详见仓库 [projects](https://github.com/alibaba/form-render/projects/2)
 
 ## 支持
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@
 - <a href="https://alibaba.github.io/form-render/docs/demo/index.html" target="_blank">Playground</a> / <a href="https://codesandbox.io/s/form-renderjichudemo-8k1l5?fontsize=14" target="_blank">Code Sandbox</a>
 - <a href="https://alibaba.github.io/form-render/#/docs/used" target="_blank">常见场景</a>
 - <a href="https://alibaba.github.io/form-render/#/docs/proptypes" target="_blank">Proptypes to Json Schema</a>
+- <a href="https://github.com/alibaba/form-render/blob/master/CHANGELOG.md" target="_blank">更新日志</a>
+- <a href="https://github.com/alibaba/form-render/projects/2" target="_blank">后期规划</a>
 
 ## 优势
 
@@ -56,7 +58,7 @@ const propsSchema = {
     string: {
       title: '字符串',
       type: 'string',
-      'ui:width': '50%', // uiSchema 可以合并到 propsSchema 中
+      'ui:width': '50%', // uiSchema 可以合并到 propsSchema 中（推荐写法，书写便捷）
     },
     select: {
       title: '单选',
@@ -66,10 +68,10 @@ const propsSchema = {
   },
 };
 
-// 也可以选择单独使用 uiSchema 字段分开定义每个字段的 ui 属性
+// 也可以选择单独使用 uiSchema 字段分开定义所有的 ui 属性，适用于遵循 json schema 的团队无缝接入
 const uiSchema = {
   select: {
-    'ui:width': '50%',
+    'ui:disabled': true,
   },
 };
 
@@ -106,17 +108,17 @@ ReactDOM.render(<Demo />, rootElement);
 
 ### API
 
-| Prop              |    Type    | Required | Default  |                   Description                   |
-| ----------------- | :--------: | :------: | :------: | :---------------------------------------------: |
-| **`name`**        |  `String`  |   `Y`    | `$form`  |                   表单的名称                    |
-| **`propsSchema`** |  `Object`  |   `Y`    |   `{}`   |                表单属性配置 json                |
-| **`uiSchema`**    |  `Object`  |   `N`    |   `{}`   |                表单 UI 配置 json                |
-| **`formData`**    |  `Object`  |   `N`    |   `{}`   |                    配置数据                     |
-| **`onChange`**    | `Function` |   `Y`    | `()=>{}` |                数据更改回调函数                 |
-| **`onValidate`**  | `Function` |   `N`    | `()=>{}` |                表单输入校验回调                 |
-| **`displayType`** |  `String`  |   `N`    | `column` |   设置表单横向排列或者纵向排序`column`/ `row`   |
-| **`readOnly`**    | `Boolean`  |   `N`    | `false`  |               预览模式/可编辑模式               |
-| **`labelWidth`**  |  `Number`  |   `N`    |  `120`   | label 的长度，指明 label 的长度（px），默认 120 |
+| Prop              |    Type    | Required |  Default   |                   Description                   |
+| ----------------- | :--------: | :------: | :--------: | :---------------------------------------------: |
+| **`name`**        |  `String`  |   `Y`    |  `$form`   |                   表单的名称                    |
+| **`propsSchema`** |  `Object`  |   `Y`    |    `{}`    |                表单属性配置 json                |
+| **`uiSchema`**    |  `Object`  |   `N`    |    `{}`    |                表单 UI 配置 json                |
+| **`formData`**    |  `Object`  |   `N`    |    `{}`    |                    配置数据                     |
+| **`onChange`**    | `Function` |   `Y`    | `() => {}` |                数据更改回调函数                 |
+| **`onValidate`**  | `Function` |   `N`    | `() => {}` |                表单输入校验回调                 |
+| **`displayType`** |  `String`  |   `N`    |  `column`  |   设置表单横向排列或者纵向排序`column`/ `row`   |
+| **`readOnly`**    | `Boolean`  |   `N`    |  `false`   |               预览模式/可编辑模式               |
+| **`labelWidth`**  |  `Number`  |   `N`    |   `120`    | label 的长度，指明 label 的长度（px），默认 120 |
 
 **注 1：** 设置表单 `displayType` 为 row 时候，请设置 `showDescIcon` 为 `true`，隐藏说明，效果会更好  
 **注 2：** **onChange** 方法会用于初始化表单 data，如果不写会造成没有初始值的表单元素无法渲染（出现不报错也不显示的情况）  
@@ -135,7 +137,7 @@ ReactDOM.render(<Demo />, rootElement);
 ## 快速书写 schema
 
 快速准确书写 schema 一直是使用者的痛点。为此我们准备了 schema 书写利器： `form-render snippets`（vscode 插件），在 vscode 商店输入 ‘formrender’ 搜索：
-![](https://img.alicdn.com/tfs/TB1VIfBqWL7gK0jSZFBXXXZZpXa-1976-1464.png)
+<img src="https://img.alicdn.com/tfs/TB1VIfBqWL7gK0jSZFBXXXZZpXa-1976-1464.png" width="500" />
 
 ## 支持 TypeScript
 
@@ -174,10 +176,6 @@ FormRender 底层引擎用原生 JS 来实现，通过解析 JSON Schema 配置�
 > npm i
 > npm start
 ```
-
-## 后期规划
-
-详见仓库 [projects](https://github.com/alibaba/form-render/projects/2)
 
 ## 支持
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,30 +1,31 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <meta charset="UTF-8">
-  <link rel="icon" href="https://img.alicdn.com/tfs/TB17UtINiLaK1RjSZFxXXamPFXa-606-643.png" type="image/png" />
-  <title>FormRender Playground</title><% (htmlWebpackPlugin.options.resources.css || []).forEach(function(path) { %>
-  <link rel="stylesheet" href="//unpkg.com/<%=path%>" />
-  <% }) %>
-</head>
-<body>
-<div id="__render_content_"></div>
-<% (htmlWebpackPlugin.options.resources.js || []).forEach(function(path) { %>
-<script src="//unpkg.com/<%=path%>"></script>
-<% }) %>
-<script>
-  function loadScript(url) {
-    var script = document.createElement('script');
-    script.src = url;
-    var firstScript = document.getElementsByTagName('script')[0];
-    firstScript.parentNode.insertBefore(script, firstScript);
-  }
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" href="https://img.alicdn.com/tfs/TB17UtINiLaK1RjSZFxXXamPFXa-606-643.png" type="image/png" />
+    <title>FormRender Playground</title>
+    <% (htmlWebpackPlugin.options.resources.css || []).forEach(function(path) { %>
+    <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/<%=path%>" />
+    <% }) %>
+  </head>
+  <body>
+    <div id="__render_content_"></div>
+    <% (htmlWebpackPlugin.options.resources.js || []).forEach(function(path) { %>
+    <script src="//cdn.jsdelivr.net/npm/<%=path%>"></script>
+    <% }) %>
+    <script>
+      function loadScript(url) {
+        var script = document.createElement('script');
+        script.src = url;
+        var firstScript = document.getElementsByTagName('script')[0];
+        firstScript.parentNode.insertBefore(script, firstScript);
+      }
 
-  if (window.location.port === '9000') {
-    loadScript('main.bundle.js')
-  } else {
-    loadScript('//unpkg.com/form-render/docs/demo/main.bundle.js')
-  }
-</script>
-</body>
+      if (window.location.port === '9000') {
+        loadScript('main.bundle.js');
+      } else {
+        loadScript('//cdn.jsdelivr.net/npm/form-render/docs/demo/main.bundle.js');
+      }
+    </script>
+  </body>
 </html>

--- a/demo/index.js
+++ b/demo/index.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
 import GithubCorner from 'react-github-corner';
 import Demo from './main';
-import { Radio, Select, Switch, Collapse } from 'antd';
+import { Radio, Select, Switch, Collapse, Slider } from 'antd';
 
 const Option = Select.Option;
 const RadioGroup = Radio.Group;
@@ -12,8 +12,6 @@ const themeList = [
   { label: 'antd主题', value: 'antd' },
   { label: 'fusion主题', value: 'fusion' },
 ];
-const FRadio = props => <Radio {...props} style={{ marginBottom: 12 }} />;
-
 class Root extends Component {
   state = {
     schemaName: 'default',
@@ -22,18 +20,15 @@ class Root extends Component {
     displayType: 'column',
     showDescIcon: false,
     readOnly: false,
+    labelWidth: 120,
   };
 
   onThemeChange = e => {
-    this.setState({
-      theme: e.target.value,
-    });
+    this.setState({ theme: e.target.value });
   };
 
   onColumnNumberChange = value => {
-    this.setState({
-      column: value,
-    });
+    this.setState({ column: value });
   };
 
   onDisplayChange = value => {
@@ -44,9 +39,7 @@ class Root extends Component {
   };
 
   onShowDescChange = value => {
-    this.setState({
-      showDescIcon: value,
-    });
+    this.setState({ showDescIcon: value });
   };
 
   onReadOnlyChange = value => this.setState({ readOnly: value });
@@ -55,8 +48,12 @@ class Root extends Component {
     this.setState({ schemaName: e.target.value });
   };
 
+  onLabelWidthChange = value => {
+    this.setState({ labelWidth: value });
+  };
+
   render() {
-    const { showDescIcon, readOnly } = this.state;
+    const { showDescIcon, readOnly, labelWidth } = this.state;
     return (
       <div className="vh-100 overflow-auto flex flex-column">
         <GithubCorner
@@ -66,32 +63,29 @@ class Root extends Component {
         />
         <Collapse defaultActiveKey={['1']} onChange={() => {}}>
           <Panel header={<div className="b f3">FormRender</div>} key="1">
-            <div className="w-100 flex items-center">
-              <div className="w-50">
-                <Radio.Group
-                  name="schemaName"
-                  defaultValue="simplest"
-                  className="flex flex-wrap"
-                  style={{ height: 20 }}
-                  onChange={this.onSchemaChange}
-                >
-                  <FRadio value="simplest">最简样例</FRadio>
-                  <FRadio value="basic">基础控件</FRadio>
-                  <FRadio value="input">个性输入框</FRadio>
-                  <FRadio value="select">个性选择框</FRadio>
-                  <FRadio value="date">日期</FRadio>
-                  <FRadio value="new-feature">新功能</FRadio>
-                  <FRadio value="demo">完整例子</FRadio>
-                </Radio.Group>
-              </div>
-              <div className="w-50 flex items-center justify-end z-999">
+            <div className="w-100 flex">
+              <Radio.Group
+                name="schemaName"
+                defaultValue="simplest"
+                className="w-50 flex items-center flex-wrap z-999"
+                onChange={this.onSchemaChange}
+              >
+                <Radio value="simplest">最简样例</Radio>
+                <Radio value="basic">基础控件</Radio>
+                <Radio value="input">个性输入框</Radio>
+                <Radio value="select">个性选择框</Radio>
+                <Radio value="date">日期</Radio>
+                <Radio value="new-feature">新功能</Radio>
+                <Radio value="demo">完整例子</Radio>
+              </Radio.Group>
+              <div className="w-50 flex items-center flex-wrap z-999">
                 <RadioGroup
                   options={themeList}
                   value={this.state.theme}
                   onChange={this.onThemeChange}
                 />
                 <Select
-                  style={{ marginRight: 12 }}
+                  style={{ marginRight: 8 }}
                   onChange={this.onColumnNumberChange}
                   defaultValue="1"
                 >
@@ -100,7 +94,7 @@ class Root extends Component {
                   <Option value="3">一行三列</Option>
                 </Select>
                 <Select
-                  style={{ marginRight: 12 }}
+                  style={{ marginRight: 8 }}
                   onChange={this.onDisplayChange}
                   defaultValue="column"
                 >
@@ -108,18 +102,26 @@ class Root extends Component {
                   <Option value="row">左右排列</Option>
                 </Select>
                 <Switch
-                  className="mr2"
+                  style={{ marginRight: 8 }}
                   checkedChildren="关描述"
                   onChange={this.onShowDescChange}
                   unCheckedChildren="开描述"
                   checked={showDescIcon}
                 />
                 <Switch
-                  className="mr2"
-                  checkedChildren="编辑模式"
+                  style={{ marginRight: 8 }}
+                  checkedChildren="编辑"
                   onChange={this.onReadOnlyChange}
-                  unCheckedChildren="只读模式"
+                  unCheckedChildren="只读"
                   checked={readOnly}
+                />
+                <div style={{ width: 42 }}>标签：</div>
+                <Slider
+                  style={{ width: 80 }}
+                  max={200}
+                  min={20}
+                  value={labelWidth}
+                  onChange={this.onLabelWidthChange}
                 />
               </div>
             </div>

--- a/demo/index2.js
+++ b/demo/index2.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import FormRender from '../src/antd';
+// import FormRender from '../src/antd';
+import FormRender from '../src/fusion';
+import '@alifd/next/dist/next.min.css';
 import SCHEMA from './json/basic.json';
 
 // const SCHEMA = {

--- a/demo/json/demo.json
+++ b/demo/json/demo.json
@@ -119,16 +119,16 @@
         "items": {
           "type": "object",
           "properties": {
+            "num": {
+              "title": "数字参数",
+              "description": "number类型",
+              "type": "number"
+            },
             "name": {
               "title": "字符名称",
               "description": "string类型",
               "type": "string",
               "pattern": "^[A-Za-z0-9]+$"
-            },
-            "num": {
-              "title": "数字参数",
-              "description": "number类型",
-              "type": "number"
             }
           }
         }
@@ -165,13 +165,28 @@
       "ui:widget": "upload",
       "ui:action": "https://www.mocky.io/v2/5cc8019d300000980a055e76"
     },
+    "objDemo": {
+      "background": {
+        "ui:hidden": "{{rootValue.isLike === false}}",
+        "ui:widget": "color"
+      },
+      "wayToTravel": {
+        "ui:widget": "radio"
+      },
+      "canDrive": {
+        "ui:hidden": "{{rootValue.wayToTravel !== 'self'}}"
+      }
+    },
+    "multiSelectDemo": {
+      "ui:widget": "multiSelect"
+    },
     "arrDemo": {
       "ui:options": {
         "foldable": true
       },
       "items": {
         "name": {
-          "ui:hidden": "num==3"
+          "ui:disabled": "{{rootValue.num === 3}}"
         }
       },
       "ui:extraButtons": [
@@ -181,21 +196,6 @@
           "callback": "copyLast"
         }
       ]
-    },
-    "objDemo": {
-      "background": {
-        "ui:dependShow": "'{{objDemo.isLike}}' == 'true'",
-        "ui:widget": "color"
-      },
-      "wayToTravel": {
-        "ui:widget": "radio"
-      },
-      "canDrive": {
-        "ui:hidden": "wayToTravel!='self'"
-      }
-    },
-    "multiSelectDemo": {
-      "ui:widget": "multiSelect"
     }
   },
   "formData": {

--- a/demo/json/new-feature.json
+++ b/demo/json/new-feature.json
@@ -52,8 +52,8 @@
           "properties": {
             "age": {
               "title": "填写年龄",
-              "type": "string",
-              "ui:hidden": "movieType=='a'||movieType=='c'"
+              "type": "number",
+              "ui:hidden": "{{rootValue.movieType === 'a' || rootValue.movieType === 'c'}}"
             },
             "movieType": {
               "title": "短片类型",

--- a/demo/main.js
+++ b/demo/main.js
@@ -70,9 +70,8 @@ class Demo extends React.Component {
   };
 
   render() {
-    const { theme, column, displayType, showDescIcon, readOnly } = this.props;
+    const { theme, ...formProps } = this.props;
     const { schemaStr } = this.state;
-    const formProps = { column, displayType, showDescIcon, readOnly };
     const FormRender = theme === 'antd' ? AntdComp : FusionComp;
     let schema = {};
     try {

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,5 +1,6 @@
 - **基础使用**
   - [快速开始](README)
+  - [如何在 TypeScript 项目中使用](docs/typescript)
   - [propSchema 配置](docs/prop-schema)
   - [uiSchema 配置](docs/ui-schema)
   - [pattern 自定义正则校验](docs/pattern)

--- a/docs/demo/index.html
+++ b/docs/demo/index.html
@@ -4,21 +4,23 @@
     <meta charset="UTF-8" />
     <link rel="icon" href="https://img.alicdn.com/tfs/TB17UtINiLaK1RjSZFxXXamPFXa-606-643.png" type="image/png" />
     <title>FormRender Playground</title>
+    
     <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/@alifd/next@1.x/dist/next.min.css" />
+    
   </head>
   <body>
     <div id="__render_content_"></div>
-
+    
     <script src="//cdn.jsdelivr.net/npm/react@16.x/umd/react.development.js"></script>
-
+    
     <script src="//cdn.jsdelivr.net/npm/react-dom@16.x/umd/react-dom.development.js"></script>
-
+    
     <script src="//cdn.jsdelivr.net/npm/prop-types@15.x/prop-types.min.js"></script>
-
+    
     <script src="//cdn.jsdelivr.net/npm/moment@2.24.0/min/moment.min.js"></script>
-
+    
     <script src="//cdn.jsdelivr.net/npm/@alifd/next@1.x/dist/next.min.js"></script>
-
+    
     <script>
       function loadScript(url) {
         var script = document.createElement('script');

--- a/docs/demo/index.html
+++ b/docs/demo/index.html
@@ -1,38 +1,37 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <meta charset="UTF-8">
-  <link rel="icon" href="https://img.alicdn.com/tfs/TB17UtINiLaK1RjSZFxXXamPFXa-606-643.png" type="image/png" />
-  <title>FormRender Playground</title>
-  <link rel="stylesheet" href="//unpkg.com/@alifd/next@1.x/dist/next.min.css" />
-  
-</head>
-<body>
-<div id="__render_content_"></div>
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" href="https://img.alicdn.com/tfs/TB17UtINiLaK1RjSZFxXXamPFXa-606-643.png" type="image/png" />
+    <title>FormRender Playground</title>
+    <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/@alifd/next@1.x/dist/next.min.css" />
+  </head>
+  <body>
+    <div id="__render_content_"></div>
 
-<script src="//unpkg.com/react@16.x/umd/react.development.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/react@16.x/umd/react.development.js"></script>
 
-<script src="//unpkg.com/react-dom@16.x/umd/react-dom.development.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/react-dom@16.x/umd/react-dom.development.js"></script>
 
-<script src="//unpkg.com/prop-types@15.x/prop-types.min.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/prop-types@15.x/prop-types.min.js"></script>
 
-<script src="//unpkg.com/moment@2.24.0/min/moment.min.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/moment@2.24.0/min/moment.min.js"></script>
 
-<script src="//unpkg.com/@alifd/next@1.x/dist/next.min.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/@alifd/next@1.x/dist/next.min.js"></script>
 
-<script>
-  function loadScript(url) {
-    var script = document.createElement('script');
-    script.src = url;
-    var firstScript = document.getElementsByTagName('script')[0];
-    firstScript.parentNode.insertBefore(script, firstScript);
-  }
+    <script>
+      function loadScript(url) {
+        var script = document.createElement('script');
+        script.src = url;
+        var firstScript = document.getElementsByTagName('script')[0];
+        firstScript.parentNode.insertBefore(script, firstScript);
+      }
 
-  if (window.location.port === '9000') {
-    loadScript('main.bundle.js')
-  } else {
-    loadScript('//unpkg.com/form-render/docs/demo/main.bundle.js')
-  }
-</script>
-</body>
+      if (window.location.port === '9000') {
+        loadScript('main.bundle.js');
+      } else {
+        loadScript('//cdn.jsdelivr.net/npm/form-render/docs/demo/main.bundle.js');
+      }
+    </script>
+  </body>
 </html>

--- a/docs/function.md
+++ b/docs/function.md
@@ -38,7 +38,7 @@
 }
 ```
 
-如果 schema 需要通过服务端传递，不得不使用 JSON 形式呢？这样就无法使用函数解析式作为属性的值了，此时，form-render 提供了以`@`起始的字段作为替代品：
+如果 schema 需要通过服务端传递，不得不使用 JSON 形式呢？这样就无法使用函数解析式作为属性的值了，此时，form-render 提供了以`{{}}`包含的字段表达函数：
 
 ```js
 {
@@ -49,18 +49,20 @@
         title: "单选",
         type: "string",
         enum: () => ["a", "b", "c"],
-        "ui:disabled": "@rootValue.input1.length > 5"
+        "ui:disabled": "{{rootValue.input1.length > 5}}"
       },
       input1: {
         title: "输入框",
         type: "string",
-        "ui:hidden": "@formData.select === 'b'"
+        "ui:hidden": "{{formData.select === 'b'}}"
       }
     }
   }
 }
 ```
 
-我们可以看到，form-render 会以首字母`@`作为提示符，将之后的字符串作为函数解析并返回，且这段字符串可包含 `formData` 和 `rootValue`
+form-render 以`{{}}`作为提示符，将其包含的字符串作为函数解析并返回运算结果。与函数相同，这段字符串可调用 `formData` 和 `rootValue` 两个参数。
 
-更复杂和定制化的表单需求建议使用自定义组件。form-render 的设计理念非常推崇组件的即插即用，详见“自定义组件” 章节
+注：在上一个版本我们使用`@`作为函数表达式的提示符，现在仍然兼容，但往后推荐用`{{}}`。主要原因是 1. `{{}}`作为表达式提示符在广大模板引擎里已经是默认，2. `@`可能真实会被用于字符串输入内容，产生误解析。
+
+更复杂和定制化的表单需求建议使用自定义组件。form-render 的设计理念非常推崇组件的即插即用，详见[自定义组件](docs/widget)章节。

--- a/docs/prop-schema.md
+++ b/docs/prop-schema.md
@@ -46,10 +46,66 @@
 - `format`：用来描述输入框的格式，支持 image、dateTime、date、time
 - `pattern`：自定义正则校验，用于校验 string 或 number 数据是否合格，详细使用可见 <a href="https://alibaba.github.io/form-render/#/docs/pattern" target="_blank">pattern 自定义正则校验</a>
 - `message` 校验提示自定义文案，与 pattern 共同使用
+- `default` 默认值，对象类型不能使用 default，其他类型包括 array 都可以使用 default：
+
+```json
+"list": {
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "string",
+      }
+    }
+  },
+  "default": [{ "x": "a" }, { "x": "b" }]
+}
+```
 
 #### String
 
-string 类对应的控件非常多：
+string 类对应的控件非常多, 使用 `format` 字段指定使用组件：
+
+```json
+// 默认 input
+"input": {
+  "title": "简单输入框",
+  "type": "string",
+}
+// textarea
+"textarea": {
+  "title": "简单文本编辑框",
+  "type": "string",
+  "format": "textarea"
+}
+// 颜色组件
+"color": {
+  "title": "颜色选择",
+  "type": "string",
+  "format": "color"
+}
+// 日期组件
+"date": {
+  "title": "日期选择",
+  "type": "string",
+  "format": "date" // "dateTime"
+}
+// 时间组件
+"time": {
+  "title": "时间选择",
+  "type": "string",
+  "format": "time"
+}
+// 图片链接组件
+"image": {
+  "title": "图片展示",
+  "type": "string",
+  "format": "image"
+}
+```
+
+注意的字段：
 
 - 输入框：input、textarea
 
@@ -72,13 +128,14 @@ string 类对应的控件非常多：
 
 #### Number
 
-- `minimum`：数字最小值
-- `maximum`：数字最大值
+- `min`：数字最小值
+- `max`：数字最大值
+- `step`：允许递增的区间
 
 #### Object
 
 - `properties`：描述 object 的结构，必要属性
-- `required`：描述对象下哪些项必填，非必要属性。使用方法传入需要限制的 name 即可
+- `required`：描述对象下哪些项必填，非必要属性。为数组结构，每项是对应必填组件的 name
 
 ```json
 {
@@ -144,7 +201,7 @@ string 类对应的控件非常多：
 - 多选框
 
   - `enum`：参考单选
-  - `enumNames`：参考单选
+  - `enumNames`：参考单选, 只写 enum 不写 enumNames 时，会默认使用 enum 作为 enumNames
 
 ```json
 {

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -18,23 +18,24 @@ Could not find a declaration file for module 'form-render/lib/antd'. '/Users/nas
     5 | const App: React.FC = () => {
 ```
 
-原因是 form-render 是 js 的组件，并没有写 typescript 的声明文件。目前在项目中成功使用 form-render 需要做以下几步：
+因为 form-render 是以 JavaScript 书写，缺少 typescript 的声明文件。
+目前在 ts 项目中使用 form-render 只需自己创建一个 `index.d.ts`，具体如下：
 
-1. 创建一个 `types` 目录，专门用来管理自己写的声明文件，将 `form-render` 的声明文件放到 `types/form-render/index.d.ts` 中。
+1. 创建一个 `types` 目录，用来存放所有声明文件。可将 `form-render` 的声明文件放到 `types/form-render/index.d.ts` 中。
 
-2. 目录结构如下：
+目录结构如下：
 
-   ```
-   /path/to/project
-   ├── src
-   |  └── index.ts
-   ├── types
-   |  └── form-render
-   |     └── index.d.ts
-   └── tsconfig.json
-   ```
+```
+/path/to/project
+├── src
+|  └── index.ts
+├── types
+|  └── form-render
+|     └── index.d.ts
+└── tsconfig.json
+```
 
-3. `tsconfig.json` 中需要 `include` types 文件夹
+2. 注意在 `tsconfig.json` 中需要 `include` types 文件夹
 
    ```json
    {
@@ -45,7 +46,7 @@ Could not find a declaration file for module 'form-render/lib/antd'. '/Users/nas
    }
    ```
 
-4. `form-render/index.d.ts` 文件如下书写, 注意使用 fusion 的同学 module 名称变为`'form-render/lib/fusion'`
+3. `form-render/index.d.ts` 文件如下书写。注意使用 fusion 的同学 module 名称变为`'form-render/lib/fusion'`
 
    ```js
    declare module 'form-render/lib/antd' {
@@ -75,4 +76,4 @@ Could not find a declaration file for module 'form-render/lib/antd'. '/Users/nas
 
    如此就大功告成啦！笔者在 codesandbox 建了一个[完整的样例](https://codesandbox.io/s/zaitypescriptxiashiyongform-render-f309f)，供大家参考。
 
-   注：在下个版本 form-render 会完全支持 typescript，无需任何操作。敬请期待！
+   注：form-render 会在后续完全支持 typescript 用户，无需更多操作。敬请期待！

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -1,0 +1,78 @@
+# 如何在 TypeScript 中使用 form-render
+
+在 typescript 中使用直接引入 from-render，会报以下错误：
+
+![](https://img.alicdn.com/tfs/TB14eJFrUT1gK0jSZFrXXcNCXXa-1003-202.png)
+
+```js
+/Users/nasa/code/try/cra-ts/src/App.tsx
+TypeScript error in /Users/nasa/code/try/cra-ts/src/App.tsx(2,24):
+Could not find a declaration file for module 'form-render/lib/antd'. '/Users/nasa/code/try/cra-ts/node_modules/form-render/lib/antd.js' implicitly has an 'any' type.
+  Try `npm install @types/form-render` if it exists or add a new declaration (.d.ts) file containing `declare module 'form-render/lib/antd';`  TS7016
+
+    1 | import React, { useState } from 'react';
+  > 2 | import FormRender from 'form-render/lib/antd';
+      |                        ^
+    3 | import SCHEMA from './schema.json';
+    4 |
+    5 | const App: React.FC = () => {
+```
+
+原因是 form-render 是 js 的组件，并没有写 typescript 的声明文件。目前在项目中成功使用 form-render 需要做以下几步：
+
+1. 创建一个 `types` 目录，专门用来管理自己写的声明文件，将 `form-render` 的声明文件放到 `types/form-render/index.d.ts` 中。
+
+2. 目录结构如下：
+
+   ```
+   /path/to/project
+   ├── src
+   |  └── index.ts
+   ├── types
+   |  └── form-render
+   |     └── index.d.ts
+   └── tsconfig.json
+   ```
+
+3. `tsconfig.json` 中需要 `include` types 文件夹
+
+   ```json
+   {
+       "compilerOptions": {
+   				...
+       },
+       "include": ["src", "types"]
+   }
+   ```
+
+4. `form-render/index.d.ts` 文件如下书写, 注意使用 fusion 的同学 module 名称变为`'form-render/lib/fusion'`
+
+   ```js
+   declare module 'form-render/lib/antd' {
+     import React from 'react';
+     export interface FRProps {
+       propsSchema: object;
+       formData: object;
+       onChange(data?: object): void;
+       name?: string;
+       column?: number;
+       uiSchema?: object;
+       widgets?: any;
+       FieldUI?: any;
+       fields?: any;
+       mapping?: object;
+       showDescIcon?: boolean;
+       showValidate?: boolean;
+       displayType?: string;
+       onValidate: any;
+       readOnly?: boolean;
+       labelWidth?: number | string;
+     }
+     class FormRender extends React.Component<FRProps> {}
+     export default FormRender;
+   }
+   ```
+
+   如此就大功告成啦！笔者在 codesandbox 建了一个[完整的样例](https://codesandbox.io/s/zaitypescriptxiashiyongform-render-f309f)，供大家参考。
+
+   注：在下个版本 form-render 会完全支持 typescript，无需任何操作。敬请期待！

--- a/index.css
+++ b/index.css
@@ -25,6 +25,7 @@
   color: #333;
   font-size: 14px;
   min-height: 22px; /* ""的标签页占位 */
+  line-height: 22px;
 }
 
 .fr-label-required {

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
   content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0"
 />
 <link rel="icon" href="https://img.alicdn.com/tfs/TB17UtINiLaK1RjSZFxXXamPFXa-606-643.png" type="image/png" />
-<link rel="stylesheet" href="//unpkg.com/form-render/docs/dist/vue.css" />
+<link rel="stylesheet" href="//cdn.jsdelivr.net/npm/form-render/docs/dist/vue.css" />
 </head>
 <body>
 <div id="app">Loading</div>
@@ -56,6 +56,6 @@
     navigator.serviceWorker.register('./docs/dist/sw.js');
   }
 </script>
-<script src="//unpkg.com/form-render/docs/dist/docsify.min.js"></script>
+<script src="//cdn.jsdelivr.net/npm/form-render/docs/dist/docsify.min.js"></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "form-render",
-  "version": "0.4.4-beta",
+  "version": "0.4.4",
   "description": "通过 JSON Schema 生成标准 Form，常用于自定义搭建配置界面生成",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "form-render",
-  "version": "0.4.3",
+  "version": "0.4.4-beta",
   "description": "通过 JSON Schema 生成标准 Form，常用于自定义搭建配置界面生成",
   "repository": {
     "type": "git",

--- a/src/base/asField.jsx
+++ b/src/base/asField.jsx
@@ -197,6 +197,7 @@ export const DefaultFieldUI = ({
         labelClass += ' ml2';
         labelClass = labelClass.replace('mb2', 'mb0');
       }
+      contentClass += ' flex items-center'; // checkbox高度短，需要居中对齐
       fieldClass += ' flex flex-row-reverse justify-end';
       break;
     default:

--- a/src/base/asField.jsx
+++ b/src/base/asField.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { getValidateText } from './validate';
 import { isHidden, isDependShow } from './isHidden';
-import { evaluateString, isLooselyNumber } from './utils';
+import { evaluateString, isLooselyNumber, isFunction } from './utils';
 
 // asField拆分成逻辑组件和展示组件，从而可替换展示组件的方式完全插拔fr的样式
 export const asField = ({ FieldUI, Widget }) => {
@@ -27,8 +27,8 @@ export const asField = ({ FieldUI, Widget }) => {
     const convertValue = item => {
       if (typeof item === 'function') {
         return item(formData, rootValue);
-      } else if (typeof item === 'string' && item.substring(0, 1) === '@') {
-        const _item = item.substring(1);
+      } else if (typeof item === 'string' && isFunction(item) !== false) {
+        const _item = isFunction(item);
         try {
           return evaluateString(_item, formData, rootValue);
         } catch (error) {

--- a/src/base/utils.js
+++ b/src/base/utils.js
@@ -165,13 +165,20 @@ export const evaluateString = (string, formData, rootValue) =>
     return (${string})`)();
 
 // 判断schema的值是是否是“函数”
-// JSON无法使用函数值的参数，所以使用@起始的字符串作为解析标记
+// JSON无法使用函数值的参数，所以使用"{{...}}"来标记为函数，也可使用@标记，不推荐。
 export function isFunction(func) {
   if (typeof func === 'function') {
     return true;
   }
   if (typeof func === 'string' && func.substring(0, 1) === '@') {
-    return true;
+    return func.substring(1);
+  }
+  if (
+    typeof func === 'string' &&
+    func.substring(0, 2) === '{{' &&
+    func.substring(func.length - 2, func.length) === '}}'
+  ) {
+    return func.substring(2, func.length - 2);
   }
   return false;
 }

--- a/src/base/validate.js
+++ b/src/base/validate.js
@@ -5,7 +5,7 @@
 
 import isLength from 'validator/lib/isLength';
 import { isHidden } from './isHidden';
-import { hasRepeat } from './utils';
+import { hasRepeat, isFunction } from './utils';
 
 const isEmptyObject = obj =>
   Object.keys(obj).length === 0 && obj.constructor === Object;
@@ -151,9 +151,10 @@ export const dealTypeValidate = (key, value, schema = {}) => {
   return checkList;
 };
 
+// for backward compatibility
 const keyHidden = (schema, val) => {
   let hidden = schema && schema['ui:hidden'];
-  if (typeof hidden === 'string' && hidden.substring(0, 1) !== '@') {
+  if (typeof hidden === 'string' && isFunction(hidden) === false) {
     hidden = isHidden({ hidden, rootValue: val });
   }
   return hidden;

--- a/src/base/validate.js
+++ b/src/base/validate.js
@@ -67,13 +67,13 @@ export const getValidateText = (obj = {}) => {
     ) {
       return (message && message.minLength) || `长度不能小于 ${minLength}`;
     }
-    // 由于有人填写red，rgba(0,123,65,0.3)等值，所以暂时不做验证
-    // if (format === 'color' || widget === 'color') {
-    //   const isHex = finalValue.match(/^(#{0,1})([0-9A-F]{6})$/i);
-    //   if (!isHex) {
-    //     return '请填写正确hex值';
-    //   }
-    // }
+    // 由于有人填写red，rgba(0,123,65,0.3)等值，所以暂时不做严格验证
+    if (format === 'color' || widget === 'color') {
+      const seemsLikeHex = finalValue.match(/^([0-9A-F]{6})$/i);
+      if (seemsLikeHex) {
+        return '颜色hex值请以#开头，例如#fff123';
+      }
+    }
   }
 
   // 数字相关校验

--- a/src/components/descriptionList1.jsx
+++ b/src/components/descriptionList1.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { isHidden } from '../base/isHidden';
+import { isFunction } from '../base/utils';
 
 const getEnumValue = (value, enums, enumNames) => {
   if (Array.isArray(enums) && Array.isArray(enumNames)) {
@@ -52,7 +53,7 @@ export const getDescription = ({ schema = {}, value = [], index }) => {
   const descList = titles.map((t, idx) => {
     let hidden = t && t['ui:hidden'];
     // ui:hidden为判断式时解析 TODO: 解析在外部集中做
-    if (typeof hidden === 'string' && hidden.substring(0, 1) !== '@') {
+    if (typeof hidden === 'string' && isFunction(hidden) === false) {
       hidden = isHidden({ hidden, rootValue: description });
     }
     if (hidden) return;

--- a/src/components/listHoc.jsx
+++ b/src/components/listHoc.jsx
@@ -93,9 +93,18 @@ const fieldListHoc = ButtonComponent => {
       p.onChange(p.name, value);
       addUnfoldItem();
     };
+    // buttons is a list, each item looks like:
+    // {
+    //   "text": "删除全部",
+    //   "icon": "delete",
+    //   "callback": "clearAll"
+    // }
 
     render() {
       const { p, foldList = [], toggleFoldItem } = this.props;
+      const { options, extraButtons } = p || {};
+      // prefer ui:options/buttons to ui:extraButtons, but keep both for backwards compatibility
+      const buttons = options.buttons || extraButtons || [];
       const { readonly, schema = {} } = p;
       const { maxItems } = schema;
       const list = p.value || [];
@@ -128,12 +137,13 @@ const fieldListHoc = ButtonComponent => {
                   新增
                 </ButtonComponent>
               )}
-              {p.extrafrButtons &&
-                p.extrafrButtons.length > 0 &&
-                p.extrafrButtons.map(item => (
+              {buttons &&
+                buttons.length > 0 &&
+                buttons.map((item, i) => (
                   <ButtonComponent
                     className="ml2"
                     icon={item.icon}
+                    key={i.toString()}
                     onClick={() => {
                       if (item.callback === 'clearAll') {
                         p.onChange(p.name, []);
@@ -149,7 +159,9 @@ const fieldListHoc = ButtonComponent => {
                         return;
                       }
                       if (typeof window[item.callback] === 'function') {
-                        window[item.callback].call(); // eslint-disable-line
+                        const value = [...p.value];
+                        const onChange = value => p.onChange(p.name, value);
+                        window[item.callback](value, onChange); // eslint-disable-line
                       }
                     }}
                   >

--- a/src/components/listHoc.jsx
+++ b/src/components/listHoc.jsx
@@ -161,7 +161,7 @@ const fieldListHoc = ButtonComponent => {
                       if (typeof window[item.callback] === 'function') {
                         const value = [...p.value];
                         const onChange = value => p.onChange(p.name, value);
-                        window[item.callback](value, onChange); // eslint-disable-line
+                        window[item.callback](value, onChange, p.newItem); // eslint-disable-line
                       }
                     }}
                   >

--- a/src/components/numberHoc.jsx
+++ b/src/components/numberHoc.jsx
@@ -29,8 +29,7 @@ export default NumberComponent => p => {
     <NumberComponent
       {...obj}
       style={{ width: '100%', ...style }}
-      disabled={p.disabled}
-      readOnly={p.readonly}
+      disabled={p.disabled || p.readonly}
       {...p.options}
       value={p.value}
       onChange={onChange}

--- a/src/widgets/antd/color.jsx
+++ b/src/widgets/antd/color.jsx
@@ -22,7 +22,6 @@ export default function color(p) {
           animation="slide-up"
           color={p.value ? p.value : '#ffffff'}
           onChange={onPickerChange}
-          disabled={true}
         />
       }
       {p.readonly ? (

--- a/src/widgets/antd/input.jsx
+++ b/src/widgets/antd/input.jsx
@@ -29,8 +29,7 @@ export default function input(p) {
       {...options}
       value={p.value}
       type={type}
-      disabled={p.disabled}
-      readOnly={p.readonly}
+      disabled={p.disabled || p.readonly}
       addonAfter={
         options.addonAfter ? options.addonAfter : previewNode(format, p.value)
       }

--- a/src/widgets/antd/textarea.jsx
+++ b/src/widgets/antd/textarea.jsx
@@ -12,8 +12,7 @@ export default function ta(p) {
   return (
     <TextArea
       style={style}
-      disabled={p.disabled}
-      readOnly={p.readonly}
+      disabled={p.disabled || p.readonly}
       value={p.value}
       {...ui}
       onChange={onChange}

--- a/src/widgets/fusion/color.jsx
+++ b/src/widgets/fusion/color.jsx
@@ -28,6 +28,7 @@ export default function color(p) {
         <span>{p.value || '#ffffff'}</span>
       ) : (
         <Input
+          style={{ width: '100%' }}
           placeholder="#ffffff"
           disabled={p.disabled}
           value={p.value}

--- a/src/widgets/fusion/input.jsx
+++ b/src/widgets/fusion/input.jsx
@@ -18,7 +18,9 @@ const previewNode = (format, value) => {
 };
 export default function input(p) {
   const { options = {}, invalid } = p;
-  const style = invalid ? { borderColor: '#f5222d' } : {};
+  const style = invalid
+    ? { borderColor: '#f5222d', width: '100%' }
+    : { width: '100%' };
   const { addonBefore, addonAfter, ...rest } = options;
   const { format = 'text' } = p.schema;
   const handleChange = value => p.onChange(p.name, value);

--- a/src/widgets/fusion/input.jsx
+++ b/src/widgets/fusion/input.jsx
@@ -27,8 +27,7 @@ export default function input(p) {
       style={style}
       {...rest}
       value={p.value}
-      disabled={p.disabled}
-      readOnly={p.readonly}
+      disabled={p.disabled || p.readonly}
       addonTextBefore={addonBefore ? addonBefore : ''}
       addonTextAfter={addonAfter ? addonAfter : previewNode(format, p.value)}
       onChange={handleChange}

--- a/src/widgets/fusion/list.jsx
+++ b/src/widgets/fusion/list.jsx
@@ -1,31 +1,26 @@
+import React from 'react';
 import { Button, Icon } from '@alifd/next';
 import listHoc from '../../components/listHoc';
 
-class FrButton extends React.Component {
-  constructor(props) {
-    super(props);
+function FrButton({ icon, children, ...rest }) {
+  let iconName;
+  switch (icon) {
+    case 'file-add':
+      iconName = 'add';
+      break;
+    case 'delete':
+      iconName = 'ashbin';
+      break;
+    default:
+      iconName = icon;
+      break;
   }
-  render() {
-    const { icon } = this.props;
-    let iconName;
-    switch (icon) {
-      case 'file-add':
-        iconName = 'add';
-        break;
-      case 'delete':
-        iconName = 'ashbin';
-        break;
-      default:
-        iconName = icon;
-        break;
-    }
-    return (
-      <Button {...this.props}>
-        {iconName ? <Icon type={iconName} /> : null}
-        {this.props.children}
-      </Button>
-    );
-  }
+  return (
+    <Button {...rest}>
+      {iconName ? <Icon type={iconName} /> : null}
+      {children}
+    </Button>
+  );
 }
 
 export default listHoc(FrButton);

--- a/src/widgets/fusion/textarea.jsx
+++ b/src/widgets/fusion/textarea.jsx
@@ -5,7 +5,9 @@ const { TextArea } = Input;
 
 export default function ta(p) {
   const { options, invalid } = p;
-  const style = invalid ? { borderColor: '#f5222d' } : {};
+  const style = invalid
+    ? { borderColor: '#f5222d', width: '100%' }
+    : { width: '100%' };
   const onChange = value => p.onChange(p.name, value);
   return (
     <TextArea

--- a/src/widgets/fusion/textarea.jsx
+++ b/src/widgets/fusion/textarea.jsx
@@ -11,9 +11,8 @@ export default function ta(p) {
     <TextArea
       style={style}
       {...options}
-      disabled={p.disabled}
+      disabled={p.disabled || p.readonly}
       value={p.value}
-      readOnly={p.readonly}
       onChange={onChange}
     />
   );


### PR DESCRIPTION
- [+] 添加了 typescript 如何使用 form-render 的说明文档
- [+] 为了属性的规范化，列表组件添加了`"ui:options"`/`"buttons"` 属性, buttons 的 callback 可调用参数 value 和 onChange，便于直接操作当前数组，详见文档
- [!] json 里书写函数表达式现在推荐使用 `"{{...}}"` 的方式，同时继续兼容 `"@..."`
- [!] 大幅更新了文档，ts 支持，form-render 后期规划，同时更新了初始 demo 的搭建代码
- [!] 只读模式下，UI 统一使用 disabled 的状态展示
- [!] 解决了有时`"ui:extraButtons"`不能正常展示的 bug
- [!] 颜色组件现在会校验 hex 值，并提示用户添加“#”（不再允许输入六位 hex 值但不输入#）
- [!] `propsSchema` 的文档补全了所有组件的常用字段
- [!] 在线 demo 添加了标签宽度控制（“左右排列”时有效）
  <img src="https://img.alicdn.com/tfs/TB1h1ZGrQT2gK0jSZFkXXcIQFXa-816-476.jpg" width="400" />