### PR TITLE
Dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### 0.5.1
+
+- [+] 新增 `ui:labelWidth` 属性，考虑到同个 FR 渲染的不同表单、或表单的不同区块的标签展示长度可能会不同，添加此个性化设置。所有字段都可以使用，效果向下继承，类似于 css 的就近覆盖规律。在线 demo 的“新功能”里有效果展示
+- [!] 当`ui:widget`字段写错时，兜底使用默认的 ui 渲染而不是 crash
+- [!] 优化了列表收缩时的样式，同时布尔值类能正确展示
+
 ### 0.5.0
 
 - [+] 【breaking change】antd 升级到 v4，同时 React 的支持也同步到 16.12.0 以上。使用方请注意！（[#60](https://github.com/alibaba/form-render/issues/60)）

--- a/README.md
+++ b/README.md
@@ -108,18 +108,18 @@ ReactDOM.render(<Demo />, rootElement);
 
 ### API
 
-| Prop             |     Type      | Required | Default  |                              Description                              |
-| ---------------- | :-----------: | :------: | :------: | :-------------------------------------------------------------------: |
-| **propsSchema**  |    Object     |    ✓     |    {}    |                           表单属性配置 json                           |
-| **uiSchema**     |    Object     |          |    {}    |              表单 UI 配置 json（可以合并到 propsSchema）              |
-| **formData**     |    Object     |          |    {}    |                               配置数据                                |
-| **onChange**     |   Function    |    ✓     | () => {} |                           数据更改回调函数                            |
-| **onValidate**   |   Function    |          | () => {} |                           表单输入校验回调                            |
-| **displayType**  |    String     |          |  column  |              设置表单横向排列或者纵向排序`column`/`row`               |
-| **showDescIcon** |    Boolean    |          |  false   |    描述是否用 tooltip 展示。`displayType`为 `row`时建议设为 `true`    |
-| **readOnly**     |    Boolean    |          |  false   |                          预览模式/可编辑模式                          |
-| **labelWidth**   | Number/String |          |   110    | label 的长度，默认 110。如为数字则单位是 px，也可以使用'20%'/'2rem'等 |
-| **widgets**      |    Object     |          |    {}    |                              自定义组件                               |
+| Prop             |     Type      | Required | Default  |                              Description                               |
+| ---------------- | :-----------: | :------: | :------: | :--------------------------------------------------------------------: |
+| **propsSchema**  |    Object     |    ✓     |    {}    |                           表单属性配置 json                            |
+| **uiSchema**     |    Object     |          |    {}    |              表单 UI 配置 json（可以合并到 propsSchema）               |
+| **formData**     |    Object     |          |    {}    |                                配置数据                                |
+| **onChange**     |   Function    |    ✓     | () => {} |                            数据更改回调函数                            |
+| **onValidate**   |   Function    |          | () => {} |                            表单输入校验回调                            |
+| **displayType**  |    String     |          |  column  |               设置表单横向排列或者纵向排序`column`/`row`               |
+| **showDescIcon** |    Boolean    |          |  false   |    描述是否用 tooltip 展示。`displayType`为 `row`时建议设为 `true`     |
+| **readOnly**     |    Boolean    |          |  false   |                          预览模式/可编辑模式                           |
+| **labelWidth**   | Number/String |          |   110    | 全局设置 label 长度(默认 110)。数字值单位为 px，也可使用'20%'/'2rem'等 |
+| **widgets**      |    Object     |          |    {}    |                               自定义组件                               |
 
 **注 1：** 设置表单 `displayType` 为 row 时候，请设置 `showDescIcon` 为 `true`，隐藏说明，效果会更好  
 **注 2：** **onChange** 方法会用于初始化表单 data，如果不写会造成没有初始值的表单元素无法渲染（出现不报错也不显示的情况）  

--- a/demo/index.js
+++ b/demo/index.js
@@ -72,11 +72,11 @@ class Root extends Component {
               >
                 <Radio value="simplest">最简样例</Radio>
                 <Radio value="basic">基础控件</Radio>
+                <Radio value="new-feature">新功能</Radio>
                 <Radio value="function">复杂联动</Radio>
                 <Radio value="input">个性输入框</Radio>
                 <Radio value="select">个性选择框</Radio>
                 <Radio value="date">日期</Radio>
-                <Radio value="new-feature">新功能</Radio>
                 <Radio value="demo">完整例子</Radio>
               </Radio.Group>
               <div className="w-50 flex items-center flex-wrap z-999">

--- a/demo/json/new-feature.json
+++ b/demo/json/new-feature.json
@@ -2,28 +2,65 @@
   "propsSchema": {
     "type": "object",
     "properties": {
-      "inputDemo": {
-        "title": "前后缀",
-        "type": "string",
-        "pattern": "^[A-Za-z0-9]+$",
-        "message": {
-          "pattern": "请输入正确格式"
+      "labelDemo": {
+        "title": "标签长度自定义",
+        "description": "在object上定义labelWidth会影响所有子元素",
+        "type": "object",
+        "ui:labelWidth": 200,
+        "properties": {
+          "inputName": {
+            "title": "简单输入框",
+            "type": "string"
+          },
+          "dateName": {
+            "title": "时间选择",
+            "type": "string",
+            "format": "date"
+          },
+          "colorName": {
+            "title": "颜色选择",
+            "type": "string",
+            "format": "color",
+            "ui:labelWidth": 80
+          }
         }
       },
-      "numberDemo": {
-        "title": "数字",
-        "description": "数字输入框",
-        "type": "number",
-        "min": 10,
-        "max": 100,
-        "step": 10
-      },
-      "dateRange": {
-        "title": "日期范围",
-        "type": "range",
-        "format": "dateTime",
-        "ui:options": {
-          "placeholder": ["开始", "结束"]
+      "objectName": {
+        "title": "对象",
+        "description": "这是一个对象类型",
+        "type": "object",
+        "properties": {
+          "inputDemo": {
+            "title": "前后缀",
+            "type": "string",
+            "pattern": "^[A-Za-z0-9]+$",
+            "message": {
+              "pattern": "请输入正确格式"
+            },
+            "ui:width": "50%",
+            "ui:options": {
+              "addonBefore": "画布长度",
+              "addonAfter": "px"
+            }
+          },
+          "numberDemo": {
+            "title": "数字",
+            "description": "数字输入框",
+            "type": "number",
+            "min": 10,
+            "max": 100,
+            "step": 10,
+            "ui:width": "50%",
+            "ui:widget": "slider"
+          },
+          "dateRange": {
+            "title": "日期范围",
+            "type": "range",
+            "format": "dateTime",
+            "ui:options": {
+              "placeholder": ["开始", "结束"]
+            }
+          }
         }
       },
       "customizedWidgets": {
@@ -33,6 +70,7 @@
           "asyncSelect": {
             "title": "异步加载的下拉框",
             "type": "string",
+            "ui:labelWidth": 130,
             "ui:widget": "asyncSelect",
             "ui:options": {
               "placeholder": "搜索淘宝商品"
@@ -88,19 +126,6 @@
           "required": ["age"]
         }
       }
-    }
-  },
-  "uiSchema": {
-    "inputDemo": {
-      "ui:width": "50%",
-      "ui:options": {
-        "addonBefore": "画布长度",
-        "addonAfter": "px"
-      }
-    },
-    "numberDemo": {
-      "ui:width": "50%",
-      "ui:widget": "slider"
     }
   },
   "formData": {

--- a/demo/json/simplest.json
+++ b/demo/json/simplest.json
@@ -9,7 +9,8 @@
       "select": {
         "title": "单选",
         "type": "string",
-        "enum": ["a", "b", "c"]
+        "enum": ["a", "b", "c"],
+        "enumNames": ["选项1", "选项2", "选项3"]
       }
     }
   }

--- a/docs/ui-schema.md
+++ b/docs/ui-schema.md
@@ -2,12 +2,12 @@
 
 ### 概述
 
-- uiSchema 虽然不是必备参数，但是通过它可以增强 FormRender 展示的丰富性
+- uiSchema 虽然不是必备参数，但是通过它可以增强 FormRender 展示的丰富性，例如：
 - 通过 uiSchema 可以覆盖 propSchema 中 type 对应的默认 widget 组件
 - 通过 `ui:disabled`、`ui:readonly`、`ui:hidden` 属性来控制表单项的 UI 展示
 - 通过 `ui:options` 属性能够实现大量特定的 ui 展示选项
 
-### 书写规范
+### 使用规范
 
 - uiSchema 里所有的字段都以 `ui:` 开始，如 `ui:widget`。
 - 为了满足各用户的使用偏好，uiSchema 可以单独书写，也可以完全归并到 propsSchema，例如：
@@ -60,9 +60,22 @@
 | 单选项 | string/number(带属性 enum) |   select    |         radio         |
 | 多选   |     array(带属性 enum)     | checkboxes  |      multiSelect      |
 
-### 控制表单项的 UI 展示（共通配置）
+### 共通的表单 UI 配置
 
 - `ui:disabled`: 可控制 input、number、date、checkbox、radio、select、switch 对于组件的 disabled 属性(变灰不可点击)
+- `ui:labelWidth` (v0.5.1) 新增。用于控制本元素以及其子元素（如果本元素是对象或列表）的标签宽度，使用方法与 FR 的全局变量`labelWidth`相同
+
+```js
+"someList": {
+  // 写法1
+  "ui:labelWidth": 180,
+  // 写法2
+  "ui:labelWidth": '4rem',
+  // 写法3
+  "ui:labelWidth": '20%',
+}
+```
+
 - `ui:readonly`：可控制 input、number 组件中的 readonly 属性(不可编辑，但不变灰)，列表也支持`readonly`，效果是列表的控件都会隐藏，导致列表不能增、删和拖拽，进入“只读”模式。但注意列表内的内容还是允许修改的，所以特别要注意如果列表套列表的场景，内部的列表也要 "ui:readonly": true
 
 ```js
@@ -103,9 +116,9 @@
 - `ui:className`：添加组件 root 元素的 className（和 fr-field 这个 className 在同级），用于自定义单独组件的样式
 - `ui:width`：单个基础组件的长度，建议使用百分比例如`"ui:width":"50%"`。
 
-### Options
+### 特定表单元素的 UI 配置（一律使用`ui:options`）
 
-- `ui:options` 里存放特定元素的特定配置。例如`textarea`的`rows`
+`ui:options` 里存放特定元素的特定配置。例如`textarea`的`rows`
 
 ```json
 "textareaDemo": {
@@ -116,13 +129,14 @@
 }
 ```
 
-基本上所有`antd`文档中组件的 props 都可以使用 `ui:options` 的方式来直接使用。除此之外我们还提供了一些特别 options：
+1. **基本上所有`antd`/ `fusion`文档中组件的 props 都可以使用 `ui:options` 的方式来直接使用。**
+2. form-render 也内置了几个的常用的`ui:options`，目前全是列表的:
 
-| option     |                    类型                     |   可用组件    |                    说明                    |
-| ---------- | :-----------------------------------------: | :-----------: | :----------------------------------------: |
-| foldable   |                   boolean                   | 列表（array） | `{ foldable: true }`用于长列表的收起和展开 |
-| hideDelete | boolean \| (formData, rootValue) => boolean | 列表（array） |    `{ hideDelete: true }`隐藏“删除”按钮    |
-| buttons    |                    array                    | 列表（array） |                    下详                    |
+| option     |                    类型                     |   可用组件    |                                      说明                                       |
+| ---------- | :-----------------------------------------: | :-----------: | :-----------------------------------------------------------------------------: |
+| foldable   |                   boolean                   | 列表（array） |                   `{ foldable: true }`用于长列表的收起和展开                    |
+| hideDelete | boolean \| (formData, rootValue) => boolean | 列表（array） | `{ hideDelete: true }`隐藏“删除”按钮。若要隐藏增删改查，使用`ui:readonly`: true |
+| buttons    |                    array                    | 列表（array） |                                      下详                                       |
 
 列表默认展示“新增”按钮。`buttons` 用于添加更多列表操作按钮
 写法如：

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "form-render",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "通过 JSON Schema 生成标准 Form，常用于自定义搭建配置界面生成",
   "repository": {
     "type": "git",

--- a/src/base/getField.js
+++ b/src/base/getField.js
@@ -30,13 +30,15 @@ export default function getField(
   // Field能否被重定义
   let fieldCanRedefine = false;
   let Field;
+  // ui:widget 是字符串，从generated中查，不是的话，就是本事
+  const _widget = typeof widget === 'string' ? generated[widget] : widget;
   if (field && !Field) {
     Field = typeof field === 'string' ? customized[field] : field;
   }
-  if (!Field && widget) {
-    Field = typeof widget === 'string' ? generated[widget] : widget;
+  if (!Field && _widget) {
+    Field = _widget;
   }
-  if (!Field && !widget) {
+  if (!Field && !_widget) {
     Field = generated[getWidgetName(schema, mapping)];
     fieldCanRedefine = !!Field;
   }

--- a/src/base/parser.js
+++ b/src/base/parser.js
@@ -58,6 +58,7 @@ function getBasicProps(settings, materials) {
     'ui:extraButtons': extraButtons = [],
     'ui:dependShow': dependShow,
     'ui:action': action,
+    'ui:labelWidth': _labelWidth,
   } = schema;
   const { required = [] } = $parent;
   const { generated: widgets, customized: fields } = materials;
@@ -75,7 +76,7 @@ function getBasicProps(settings, materials) {
     required: required.indexOf(name) !== -1,
     disabled: disabled,
     readonly: readOnly || readonly, // 前者全局的，后者单个ui的
-    labelWidth,
+    labelWidth: _labelWidth || labelWidth,
     width,
     widgets,
     fields,
@@ -106,7 +107,7 @@ function getBasicProps(settings, materials) {
           showDescIcon,
           showValidate,
           readOnly,
-          labelWidth,
+          labelWidth: _labelWidth || labelWidth,
           formData,
         },
         materials

--- a/src/components/descList.jsx
+++ b/src/components/descList.jsx
@@ -61,6 +61,8 @@ export const getDescription = ({ schema = {}, value = [], index }) => {
     let text = valueList[idx];
     if (text === null && text === undefined) {
       text = '';
+    } else if (typeof text === 'boolean') {
+      text = text ? '是' : '否';
     } else if (typeof text !== 'string' && typeof text !== 'number' && text) {
       text = '{复杂结构}';
     } else if (t.enum && t.enumNames) {

--- a/src/components/listHoc.jsx
+++ b/src/components/listHoc.jsx
@@ -74,7 +74,7 @@ const listItemHoc = ButtonComponent =>
             <FoldIcon
               fold={fold}
               onClick={this.toggleFold}
-              style={{ position: 'absolute', top: 14, right: 36 }}
+              style={{ position: 'absolute', top: 10, right: 32 }}
             />
           )}
           {!readonly && <DragHandle />}


### PR DESCRIPTION
### 0.5.1

- [+] 新增 `ui:labelWidth` 属性，考虑到同个 FR 渲染的不同表单、或表单的不同区块的标签展示长度可能会不同，添加此个性化设置。所有字段都可以使用，效果向下继承，类似于 css 的就近覆盖规律。在线 demo 的“新功能”里有效果展示
- [!] 当`ui:widget`字段写错时，兜底使用默认的 ui 渲染而不是 crash
- [!] 优化了列表收缩时的样式，同时布尔值类能正确展示