### PR TITLE
Dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 0.5.2
 
-- [+] fusion 的 datePicker 组件添加 "ui:options": { "type": "month"} (month/year/week) 配置来使用 MonthPicker / YearPicker / WeekPicker。Antd 组件下，可参考官方文档的 picker 属性。 "ui:options": { "picker": "month"} [70](https://github.com/alibaba/form-render/issues/70)
+- [+] fusion 的 datePicker 组件添加 "ui:options": { "picker": "month"} (month/year/week) 配置来使用 MonthPicker / YearPicker / WeekPicker，确保和 Antd 一致（Antd 组件在之前就支持了）。[70](https://github.com/alibaba/form-render/issues/70)
 - [!] 修复了列表的 default 值有时会覆盖 formData 的 bug [71](https://github.com/alibaba/form-render/issues/71)
 
 ### 0.5.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+### 0.5.2
+
+- [+] fusion 的 datePicker 组件添加 "ui:options": { "type": "month"} (month/year/week) 配置来使用 MonthPicker / YearPicker / WeekPicker。Antd 组件下，可参考官方文档的 picker 属性。 "ui:options": { "picker": "month"} [70](https://github.com/alibaba/form-render/issues/70)
+- [!] 修复了列表的 default 值有时会覆盖 formData 的 bug [71](https://github.com/alibaba/form-render/issues/71)
+
 ### 0.5.1
 
 - [+] 新增 `ui:labelWidth` 属性，考虑到同个 FR 渲染的不同表单、或表单的不同区块的标签展示长度可能会不同，添加此个性化设置。所有字段都可以使用，效果向下继承，类似于 css 的就近覆盖规律。在线 demo 的“新功能”里有效果展示

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [+] fusion 的 datePicker 组件添加 "ui:options": { "picker": "month"} (month/year/week) 配置来使用 MonthPicker / YearPicker / WeekPicker，确保和 Antd 一致（Antd 组件在之前就支持了）。([70](https://github.com/alibaba/form-render/issues/70))
 - [!] 修复了列表的 default 值有时会覆盖 formData 的 bug ([71](https://github.com/alibaba/form-render/issues/71))
+- [!] 修复了 antd 的默认语言的包引入为`antd/lib/locale/zh_CN`, 避免某些测试的报错。([68](https://github.com/alibaba/form-render/issues/68))
 
 ### 0.5.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ### 0.5.2
 
-- [+] fusion 的 datePicker 组件添加 "ui:options": { "picker": "month"} (month/year/week) 配置来使用 MonthPicker / YearPicker / WeekPicker，确保和 Antd 一致（Antd 组件在之前就支持了）。[70](https://github.com/alibaba/form-render/issues/70)
-- [!] 修复了列表的 default 值有时会覆盖 formData 的 bug [71](https://github.com/alibaba/form-render/issues/71)
+- [+] fusion 的 datePicker 组件添加 "ui:options": { "picker": "month"} (month/year/week) 配置来使用 MonthPicker / YearPicker / WeekPicker，确保和 Antd 一致（Antd 组件在之前就支持了）。([70](https://github.com/alibaba/form-render/issues/70))
+- [!] 修复了列表的 default 值有时会覆盖 formData 的 bug ([71](https://github.com/alibaba/form-render/issues/71))
 
 ### 0.5.1
 

--- a/docs/ui-schema.md
+++ b/docs/ui-schema.md
@@ -130,15 +130,30 @@
 ```
 
 1. **基本上所有`antd`/ `fusion`文档中组件的 props 都可以使用 `ui:options` 的方式来直接使用。**
-2. form-render 也内置了几个的常用的`ui:options`，目前全是列表的:
+2. form-render 也内置了几个的常用的`ui:options`:
 
-| option     |                    类型                     |   可用组件    |                                      说明                                       |
-| ---------- | :-----------------------------------------: | :-----------: | :-----------------------------------------------------------------------------: |
-| foldable   |                   boolean                   | 列表（array） |                   `{ foldable: true }`用于长列表的收起和展开                    |
-| hideDelete | boolean \| (formData, rootValue) => boolean | 列表（array） | `{ hideDelete: true }`隐藏“删除”按钮。若要隐藏增删改查，使用`ui:readonly`: true |
-| buttons    |                    array                    | 列表（array） |                                      下详                                       |
+| option     |                    类型                    |   可用组件    |                                      说明                                       |
+| ---------- | :----------------------------------------: | :-----------: | :-----------------------------------------------------------------------------: |
+| foldable   |                  boolean                   | 列表（array） |                   `{ foldable: true }`用于长列表的收起和展开                    |
+| hideDelete | boolean / (formData, rootValue) => boolean | 列表（array） | `{ hideDelete: true }`隐藏“删除”按钮。若要隐藏增删改查，使用`ui:readonly`: true |
+| buttons    |                   array                    | 列表（array） |                                  下详 （注 2）                                  |
+| picker     |           "week"/"month"/"year"            | 日期（date）  |               使用 WeekPicker、MonthPicker 和 YearPicker （注 1）               |
 
-列表默认展示“新增”按钮。`buttons` 用于添加更多列表操作按钮
+**注 1：** picker 的简单用法如下：
+
+```json
+// 月份选择器，picker属性可为"week"/"month"/"year"
+"monthpicker": {
+  "title": "月份选择",
+  "type": "string",
+  "format": "date",
+  "ui:options": {
+    "picker": "month"
+  }
+}
+```
+
+**注 2：** 列表默认展示“新增”按钮。`buttons` 用于添加更多列表操作按钮
 写法如：
 
 ```json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "form-render",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "通过 JSON Schema 生成标准 Form，常用于自定义搭建配置界面生成",
   "repository": {
     "type": "git",

--- a/src/antd.js
+++ b/src/antd.js
@@ -7,7 +7,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import FormRender from './index';
 import { ConfigProvider } from 'antd';
-import zhCN from 'antd/es/locale-provider/zh_CN';
+import zhCN from 'antd/lib/locale/zh_CN';
 import { mapping, widgets } from './widgets/antd';
 
 export default class AntdForm extends React.PureComponent {

--- a/src/base/resolve.js
+++ b/src/base/resolve.js
@@ -84,7 +84,7 @@ function resolve(schema, data, options = {}) {
   if (type === 'array') {
     // 如果自定义组件
     if (widget) return value;
-    if (def && Array.isArray(def)) {
+    if (def && Array.isArray(def) && !value) {
       return def;
     }
     const subs = [].concat(items || []);

--- a/src/components/dateHoc.jsx
+++ b/src/components/dateHoc.jsx
@@ -25,9 +25,13 @@ export default (p, onChange, DateComponent) => {
     ...p.options,
     ...defaultObj,
     style: { width: '100%', ...style },
-    showTime: format === 'dateTime',
     disabled: p.disabled || p.readonly,
     onChange,
   };
+
+  if (format === 'dateTime') {
+    dateParams.showTime = true;
+  }
+
   return <DateComponent {...dateParams} />;
 };

--- a/src/widgets/fusion/date.jsx
+++ b/src/widgets/fusion/date.jsx
@@ -11,7 +11,7 @@ const { MonthPicker, YearPicker, WeekPicker } = DatePicker;
 
 export default function date(p) {
   const { format = 'dateTime' } = p.schema;
-  const { type } = p.options;
+  const { picker } = p.options;
   const dateFormat = getFormat(format);
   const onChange = value => {
     let timeValue = value ? moment(value).format(dateFormat) : '';
@@ -22,7 +22,7 @@ export default function date(p) {
   if (format === 'time') {
     DateComponent = TimePicker;
   } else {
-    switch (type) {
+    switch (picker) {
       case 'month':
         DateComponent = MonthPicker;
         break;

--- a/src/widgets/fusion/date.jsx
+++ b/src/widgets/fusion/date.jsx
@@ -7,14 +7,36 @@ import { DatePicker, TimePicker } from '@alifd/next';
 import moment from 'moment';
 import dateHoc from '../../components/dateHoc';
 import { getFormat } from '../../base/utils';
+const { MonthPicker, YearPicker, WeekPicker } = DatePicker;
 
 export default function date(p) {
   const { format = 'dateTime' } = p.schema;
+  const { type } = p.options;
   const dateFormat = getFormat(format);
   const onChange = value => {
     let timeValue = value ? moment(value).format(dateFormat) : '';
     p.onChange(p.name, timeValue);
   };
-  const DateComponent = format === 'time' ? TimePicker : DatePicker;
+
+  let DateComponent = DatePicker;
+  if (format === 'time') {
+    DateComponent = TimePicker;
+  } else {
+    switch (type) {
+      case 'month':
+        DateComponent = MonthPicker;
+        break;
+      case 'week':
+        DateComponent = WeekPicker;
+        break;
+      case 'year':
+        DateComponent = YearPicker;
+        break;
+      default:
+        DateComponent = DatePicker;
+        break;
+    }
+  }
+
   return dateHoc(p, onChange, DateComponent);
 }


### PR DESCRIPTION
- [+] fusion 的 datePicker 组件添加 "ui:options": { "picker": "month"} (month/year/week) 配置来使用 MonthPicker / YearPicker / WeekPicker，确保和 Antd 一致（Antd 组件在之前就支持了）。([70](https://github.com/alibaba/form-render/issues/70))
- [!] 修复了列表的 default 值有时会覆盖 formData 的 bug ([71](https://github.com/alibaba/form-render/issues/71))
- [!] 修复了 antd 的默认语言的包引入为`antd/lib/locale/zh_CN`, 避免某些测试的报错。([68](https://github.com/alibaba/form-render/issues/68))