### PR TITLE
Dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### 0.5.6
 
-- [+] 添加 html 元素渲染的支持，使用 `default` 或 `formData` 属性传入 html 的字符串（可以是纯字符串，作为 div 渲染）
+- [+] 添加 html 元素渲染的支持，使用 `default` 或 `formData` 属性传入 html 的字符串（可以是纯字符串，作为 div 渲染），见在线 demo（新功能）
+  <img src="https://img.alicdn.com/tfs/TB18ug4XTM11u4jSZPxXXahcXXa-571-190.jpg" width="500px" />
 - [!] object/array 的`disabled`属性现在回传递到所有的子元素（方便区块的表单置灰）
 - [!] 修复从外部传入 `formData` 顺序与 schema 不同时，表单会按照 formData 的顺序渲染。现在能始终按照 schema 顺序渲染
 - [!] 修复 onChange 在首次渲染时会触发两次的问题

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+### 0.5.6
+
+- [+] 添加 html 元素渲染的支持，使用 `default` 或 `formData` 属性传入 html 的字符串（可以是纯字符串，作为 div 渲染）
+- [!] object/array 的`disabled`属性现在回传递到所有的子元素（方便区块的表单置灰）
+- [!] 修复从外部传入 `formData` 顺序与 schema 不同时，表单会按照 formData 的顺序渲染。现在能始终按照 schema 顺序渲染
+- [!] 修复 onChange 在首次渲染时会触发两次的问题
+
 ### 0.5.5
 
 - [!] 修复使用`ui:options`设置自定义 format 时实际 formData 未格式的问题（[87](https://github.com/alibaba/form-render/issues/87)）

--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@
 
 <img src="https://gw.alipayobjects.com/mdn/feizhu_pla/afts/img/A*wyH4Rq-EqwQAAAAAAAAAAABkARQnAQ?raw=true" width="750px"/>
 
-<img src="https://gw.alipayobjects.com/zos/demos_resources/ow8u14/fr-flow-short.gif" alt="schema编辑器" width='750px' />
+<img src="https://gw.alipayobjects.com/zos/demos_resources/n64ecc/fr-flow-short-par1.gif?raw=true" width="750px"/>
+
+<img src="https://gw.alipayobjects.com/zos/demos_resources/5ay8d5/fr-flow-short-par2.gif?raw=true" width='750px' />
 
 - 如上图，使用 [**shema 编辑器**](https://form-render.github.io/schema-generator/)可实现低上手成本、快速搭建
 - 支持 Ant Design 和 Fusion Design 主流的视觉主题

--- a/demo/index1.js
+++ b/demo/index1.js
@@ -1,0 +1,143 @@
+import React, { Component } from 'react';
+import ReactDOM from 'react-dom';
+import GithubCorner from 'react-github-corner';
+import Demo from './main';
+import { Radio, Select, Switch, Collapse, Slider } from 'antd';
+
+window.copyMe = (list, index) => {
+  const item = list[index];
+  list.splice(index, 0, item);
+  return list;
+};
+
+const Option = Select.Option;
+const RadioGroup = Radio.Group;
+const { Panel } = Collapse;
+// constant
+const themeList = [
+  { label: 'antd主题', value: 'antd' },
+  { label: 'fusion主题', value: 'fusion' },
+];
+class Root extends Component {
+  state = {
+    schemaName: 'default',
+    theme: 'antd',
+    column: 1,
+    displayType: 'column',
+    showDescIcon: false,
+    readOnly: false,
+    labelWidth: 110,
+  };
+
+  onThemeChange = e => {
+    this.setState({ theme: e.target.value });
+  };
+
+  onColumnNumberChange = value => {
+    this.setState({ column: value });
+  };
+
+  onDisplayChange = value => {
+    this.setState({
+      displayType: value,
+      showDescIcon: value === 'row',
+    });
+  };
+
+  onShowDescChange = value => {
+    this.setState({ showDescIcon: value });
+  };
+
+  onReadOnlyChange = value => this.setState({ readOnly: value });
+
+  onSchemaChange = e => {
+    this.setState({ schemaName: e.target.value });
+  };
+
+  onLabelWidthChange = value => {
+    this.setState({ labelWidth: value });
+  };
+
+  render() {
+    const { showDescIcon, readOnly, labelWidth } = this.state;
+    return (
+      <div className="vh-100 overflow-auto flex flex-column">
+        <GithubCorner
+          href="https://github.com/alibaba/form-render"
+          bannerColor="#F6C14F"
+          className="absolute top-0 right-0 z-999"
+        />
+        <Collapse defaultActiveKey={['1']} onChange={() => {}}>
+          <Panel header={<div className="b f3">FormRender</div>} key="1">
+            <div className="w-100 flex">
+              <Radio.Group
+                name="schemaName"
+                defaultValue="simplest"
+                className="w-50 flex items-center flex-wrap z-999"
+                onChange={this.onSchemaChange}
+              >
+                <Radio value="simplest">最简样例</Radio>
+                <Radio value="basic">基础控件</Radio>
+                <Radio value="new-feature">新功能</Radio>
+                <Radio value="function">复杂联动</Radio>
+                <Radio value="input">个性输入框</Radio>
+                <Radio value="select">个性选择框</Radio>
+                <Radio value="date">日期</Radio>
+                <Radio value="demo">完整例子</Radio>
+              </Radio.Group>
+              <div className="w-50 flex items-center flex-wrap z-999">
+                <RadioGroup
+                  options={themeList}
+                  value={this.state.theme}
+                  onChange={this.onThemeChange}
+                />
+                <Select
+                  style={{ marginRight: 8 }}
+                  onChange={this.onColumnNumberChange}
+                  defaultValue="1"
+                >
+                  <Option value="1">一行一列</Option>
+                  <Option value="2">一行二列</Option>
+                  <Option value="3">一行三列</Option>
+                </Select>
+                <Select
+                  style={{ marginRight: 8 }}
+                  onChange={this.onDisplayChange}
+                  defaultValue="column"
+                >
+                  <Option value="column">上下排列</Option>
+                  <Option value="row">左右排列</Option>
+                </Select>
+                <Switch
+                  style={{ marginRight: 8 }}
+                  checkedChildren="关描述"
+                  onChange={this.onShowDescChange}
+                  unCheckedChildren="开描述"
+                  checked={showDescIcon}
+                />
+                <Switch
+                  style={{ marginRight: 8 }}
+                  checkedChildren="编辑"
+                  onChange={this.onReadOnlyChange}
+                  unCheckedChildren="只读"
+                  checked={readOnly}
+                />
+                <div style={{ width: 42 }}>标签：</div>
+                <Slider
+                  style={{ width: 80 }}
+                  max={200}
+                  min={20}
+                  value={labelWidth}
+                  onChange={this.onLabelWidthChange}
+                />
+              </div>
+            </div>
+          </Panel>
+        </Collapse>
+        <Demo {...this.state} />
+      </div>
+    );
+  }
+}
+
+ReactDOM.render(<Root />, document.getElementById('__render_content_'));

--- a/demo/json/new-feature.json
+++ b/demo/json/new-feature.json
@@ -15,6 +15,16 @@
             "title": "使用formData",
             "type": "html",
             "default": "hello world"
+          },
+          "input": {
+            "title": "放在尾部",
+            "type": "string",
+            "ui:width": "70%"
+          },
+          "html3": {
+            "type": "html",
+            "default": "<a>注意事项</a>",
+            "ui:width": "30%"
           }
         }
       },
@@ -180,7 +190,7 @@
   },
   "formData": {
     "html": {
-      "html2": "hello from formData!"
+      "html2": "hello from <span style='color: red'>formData</span>!"
     },
     "complexArray": [
       {

--- a/demo/json/new-feature.json
+++ b/demo/json/new-feature.json
@@ -2,6 +2,22 @@
   "propsSchema": {
     "type": "object",
     "properties": {
+      "html": {
+        "title": "html元素的使用",
+        "type": "object",
+        "properties": {
+          "html1": {
+            "title": "纯字符串",
+            "type": "html",
+            "default": "hello world"
+          },
+          "html2": {
+            "title": "使用formData",
+            "type": "html",
+            "default": "hello world"
+          }
+        }
+      },
       "customItemButtons": {
         "title": "数组item自定义button",
         "type": "array",
@@ -163,8 +179,9 @@
     }
   },
   "formData": {
-    "inputDemo": "750",
-    "textareaDemo": "FormRender\nHello World!",
+    "html": {
+      "html2": "hello from formData!"
+    },
     "complexArray": [
       {
         "age": "",

--- a/docs/prop-schema.md
+++ b/docs/prop-schema.md
@@ -230,6 +230,42 @@ string 类对应的控件非常多, 使用 `format` 字段指定使用组件：
 }
 ```
 
+### html
+
+只要注明`type: "html"`, FR 支持 html 元素的渲染，最常用的是纯文本, 如下例：
+
+```json
+"html": {
+  "title": "html元素的使用",
+  "type": "object",
+  "properties": {
+    "html1": {
+      "title": "纯字符串",
+      "type": "html",
+      "default": "hello world"
+    },
+    "html2": {
+      "title": "使用formData",
+      "type": "html",
+      "default": "hello world"
+    },
+    "input": {
+      "title": "放在尾部",
+      "type": "string",
+      "ui:width": "70%"
+    },
+    "html3": {
+      "type": "html",
+      "default": "<a>注意事项</a>",
+      "ui:width": "30%"
+    }
+  }
+}
+```
+
+渲染结果如下：
+<img src="https://img.alicdn.com/tfs/TB18ug4XTM11u4jSZPxXXahcXXa-571-190.jpg" width="500px" />
+
 ### 一个很全的结构
 
 ```json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "form-render",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "通过 JSON Schema 生成标准 Form，常用于自定义搭建配置界面生成",
   "repository": {
     "type": "git",

--- a/src/base/asField.jsx
+++ b/src/base/asField.jsx
@@ -107,12 +107,12 @@ export const asField = ({ FieldUI, Widget }) => {
     if (!isComplex && width) {
       columnStyle = {
         width,
-        paddingRight: '24px',
+        paddingRight: '12px',
       };
     } else if (!isComplex && column > 1) {
       columnStyle = {
         width: `calc(100% /${column})`,
-        paddingRight: '24px',
+        paddingRight: '12px',
       };
     }
 

--- a/src/base/parser.js
+++ b/src/base/parser.js
@@ -47,6 +47,8 @@ function getBasicProps(settings, materials) {
     labelWidth,
     useLogger,
     formData,
+    // 父传子
+    disabled,
   } = settings;
   // 写错的时候
   if (!schema) return {};
@@ -56,7 +58,7 @@ function getBasicProps(settings, materials) {
     'ui:className': className,
     'ui:options': options = {},
     'ui:hidden': hidden,
-    'ui:disabled': disabled,
+    'ui:disabled': _disabled,
     'ui:width': width,
     'ui:readonly': readonly,
     'ui:extraButtons': extraButtons = [],
@@ -78,7 +80,7 @@ function getBasicProps(settings, materials) {
     options, // 所有特定组件规则，addable等规则TODO
     hidden,
     required: required.indexOf(name) !== -1,
-    disabled: disabled,
+    disabled: _disabled || disabled,
     readonly: readOnly || readonly, // 前者全局的，后者单个ui的
     labelWidth: _labelWidth || labelWidth,
     useLogger,
@@ -115,6 +117,7 @@ function getBasicProps(settings, materials) {
           labelWidth: _labelWidth || labelWidth,
           useLogger,
           formData,
+          disabled: _disabled || disabled,
         },
         materials
       ),

--- a/src/base/resolve.js
+++ b/src/base/resolve.js
@@ -59,19 +59,9 @@ function resolve(schema, data, options = {}) {
     // 按照required规则做数据补全
     checkRequired = false,
   } = options;
-  // 当前值
-  let value = getDefaultValue(schema);
 
-  try {
-    // 使用clone(data) 但确保key顺序正确
-    if (typeof data !== 'undefined') {
-      Object.keys(value).forEach(key => {
-        value[key] = clone(data)[key];
-      });
-    }
-  } catch (error) {
-    value = clone(data); // clone(data) 有时候业务方传的data的key的顺序是错的，导致了渲染顺序错误，所以这个只是兜底
-  }
+  const value =
+    typeof data === 'undefined' ? getDefaultValue(schema) : clone(data);
 
   if (type === 'object') {
     // 如果自定义组件

--- a/src/base/resolve.js
+++ b/src/base/resolve.js
@@ -60,8 +60,19 @@ function resolve(schema, data, options = {}) {
     checkRequired = false,
   } = options;
   // 当前值
-  const value =
-    typeof data === 'undefined' ? getDefaultValue(schema) : clone(data);
+  let value = getDefaultValue(schema);
+
+  try {
+    // 使用clone(data) 但确保key顺序正确
+    if (typeof data !== 'undefined') {
+      Object.keys(value).forEach(key => {
+        value[key] = clone(data)[key];
+      });
+    }
+  } catch (error) {
+    value = clone(data); // clone(data) 有时候业务方传的data的key的顺序是错的，导致了渲染顺序错误，所以这个只是兜底
+  }
+
   if (type === 'object') {
     // 如果自定义组件
     if (widget) {

--- a/src/base/resolve.js
+++ b/src/base/resolve.js
@@ -93,11 +93,13 @@ function resolve(schema, data, options = {}) {
     return ret;
   }
   if (type === 'array') {
-    // 如果自定义组件
-    if (widget) return value;
+    // 如果没有value且default有值，用default
     if (def && Array.isArray(def) && !value) {
       return def;
     }
+    // 如果自定义组件
+    if (widget) return value;
+
     const subs = [].concat(items || []);
     const ret = [];
     value.forEach &&

--- a/src/components/html.jsx
+++ b/src/components/html.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export default function html({ value, schema, onChange, ...rest }) {
+export default function html({ value, schema, ...rest }) {
   let __html = '';
   try {
     __html = value ? value : schema.default;

--- a/src/components/html.jsx
+++ b/src/components/html.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export default function html({ value, schema, onChange, ...rest }) {
+  let __html = '';
+  try {
+    __html = value ? value : schema.default;
+    if (typeof __html !== 'string') {
+      __html = '';
+    }
+  } catch (error) {}
+  return <div dangerouslySetInnerHTML={{ __html }} />;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -83,13 +83,13 @@ function FormRender({
   }, []);
 
   useEffect(() => {
-    if (!isDeepEqual(previousSchema, schema)) {
+    if (previousSchema !== undefined && !isDeepEqual(previousSchema, schema)) {
       onChange(data);
     }
   }, [schema]);
 
   useEffect(() => {
-    if (!isDeepEqual(previousData, formData)) {
+    if (previousData !== undefined && !isDeepEqual(previousData, formData)) {
       updateValidation();
     }
   }, [formData]);

--- a/src/widgets/antd/html.jsx
+++ b/src/widgets/antd/html.jsx
@@ -1,0 +1,2 @@
+import html from '../../components/html';
+export default html;

--- a/src/widgets/antd/index.jsx
+++ b/src/widgets/antd/index.jsx
@@ -14,6 +14,7 @@ import slider from './slider';
 import switch1 from './switch';
 import textarea from './textarea';
 import upload from './upload';
+import html from './html';
 
 export const widgets = {
   checkbox,
@@ -32,6 +33,7 @@ export const widgets = {
   switch: switch1,
   textarea,
   upload,
+  html,
 };
 
 export const mapping = {
@@ -42,6 +44,7 @@ export const mapping = {
   integer: 'number',
   number: 'number',
   object: 'map',
+  html: 'html',
   'string:upload': 'upload',
   'string:date': 'date',
   'string:dateTime': 'date',

--- a/src/widgets/antd/range.jsx
+++ b/src/widgets/antd/range.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Input } from 'antd';
+
+export default function range({ value, onChange, name, ...rest }) {
+  return (
+    <Input.Group compact style={{ width: '100%', display: 'flex' }}>
+      <Input
+        style={
+          {
+            // width: 100,
+            // textAlign: 'center',
+          }
+        }
+      />
+      <Input
+        className="site-input-split"
+        style={{
+          backgroundColor: '#fff',
+          width: 30,
+          borderLeft: 0,
+          borderRight: 0,
+          pointerEvents: 'none',
+          flexShrink: 0,
+        }}
+        placeholder="~"
+        disabled
+      />
+      <Input
+        style={{
+          borderLeftWidth: 0,
+          // width: 100,
+          // textAlign: 'center',
+        }}
+      />
+    </Input.Group>
+  );
+}

--- a/src/widgets/fusion/html.jsx
+++ b/src/widgets/fusion/html.jsx
@@ -1,0 +1,2 @@
+import html from '../../components/html';
+export default html;

--- a/src/widgets/fusion/index.jsx
+++ b/src/widgets/fusion/index.jsx
@@ -14,6 +14,7 @@ import slider from './slider';
 import switch1 from './switch';
 import textarea from './textarea';
 import upload from './upload';
+import html from './html';
 
 export const widgets = {
   checkbox,
@@ -32,6 +33,7 @@ export const widgets = {
   switch: switch1,
   textarea,
   upload,
+  html,
 };
 
 // 默认映射关系
@@ -43,6 +45,7 @@ export const mapping = {
   integer: 'number',
   number: 'number',
   object: 'map',
+  html: 'html',
   'string:upload': 'upload',
   'string:date': 'date',
   'string:dateTime': 'date',


### PR DESCRIPTION
- [+] 添加 html 元素渲染的支持，使用 `default` 或 `formData` 属性传入 html 的字符串（可以是纯字符串，作为 div 渲染）
- [!] object/array 的`disabled`属性现在回传递到所有的子元素（方便区块的表单置灰）
- [!] 修复从外部传入 `formData` 顺序与 schema 不同时，表单会按照 formData 的顺序渲染。现在能始终按照 schema 顺序渲染
- [!] 修复 onChange 在首次渲染时会触发两次的问题