### PR TITLE
fix: babel import plugin for @ant-design/icons

### DIFF
--- a/.fatherrc.js
+++ b/.fatherrc.js
@@ -27,5 +27,12 @@ export default {
       },
       '@alifd/next',
     ],
+    [
+      'import',
+      {
+        libraryName: '@ant-design/icons',
+        libraryDirectory: 'es',
+      },
+    ],
   ],
 };


### PR DESCRIPTION
缺失相关配置导致构建后的文件引入了整个 `@ant-design/icons`