### PR TITLE
v0.10.0

### DIFF
--- a/docs/demo/new-feature/validator.json
+++ b/docs/demo/new-feature/validator.json
@@ -1,0 +1,17 @@
+{
+  "schema": {
+    "type": "object",
+    "properties": {
+      "pwd": {
+        "title": "密码",
+        "type": "string",
+        "validator": "{{value.length > 6 ? '长度超了': ''}}"
+      },
+      "pwd2": {
+        "title": "重复输入密码",
+        "type": "string",
+        "validator": "{{formData.pwd == value ? '': '两个密码不一致'}}"
+      }
+    }
+  }
+}

--- a/docs/guide/new-feature.md
+++ b/docs/guide/new-feature.md
@@ -9,6 +9,18 @@ toc: menu
 
 # 新功能
 
+## 0.10.0
+
+新增了 validator 字段，用于动态校验
+
+```jsx
+import React from 'react';
+import FR from '../demo/FR/index.jsx';
+import json from '../demo/new-feature/validator.json';
+
+export default () => <FR schema={json} />;
+```
+
 ## 0.9.1
 
 新增了 `{ format: "email"/"url"/"image" }`

--- a/package.json
+++ b/package.json
@@ -34,5 +34,6 @@
     "react": "^16.12.0",
     "react-simple-code-editor": "^0.11.0",
     "yorkie": "^2.0.0"
-  }
+  },
+  "version": "0.10.0"
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,5 @@
     "react": "^16.12.0",
     "react-simple-code-editor": "^0.11.0",
     "yorkie": "^2.0.0"
-  },
-  "version": "0.10.0"
+  }
 }

--- a/packages/FR1.0/.fatherrc.js
+++ b/packages/FR1.0/.fatherrc.js
@@ -1,0 +1,32 @@
+import commonjs from 'rollup-plugin-commonjs';
+
+export default {
+  entry: ['src/index.js'],
+  esm: 'rollup',
+  cjs: 'babel',
+  extraRollupPlugins: [
+    commonjs({
+      include: 'node_modules/**',
+    }),
+  ],
+  extraBabelPlugins: [
+    [
+      'import',
+      {
+        libraryName: 'antd',
+        libraryDirectory: 'lib',
+        style: 'css',
+      },
+      'antd',
+    ],
+    [
+      'import',
+      {
+        libraryName: '@ant-design/icons',
+        libraryDirectory: 'lib/icons',
+        camel2DashComponentName: false,
+      },
+      '@ant-design/icons',
+    ],
+  ],
+};

--- a/packages/FR1.0/CHANGELOG.md
+++ b/packages/FR1.0/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+### 1.0.0
+
+- [+] form-render 1.0

--- a/packages/FR1.0/CONTRIBUTING.md
+++ b/packages/FR1.0/CONTRIBUTING.md
@@ -1,0 +1,41 @@
+# 如何贡献代码
+
+欢迎给 FormRender 提优化建议，或者修复已有 Bug，共促其发展
+
+## Branch 管理
+
+```
+master
+ ↑
+dev         <--- Develop/PR
+```
+
+- `dev` 分支
+  - 所有的开发均在 dev 分支进行
+  - 提 PR 时候请提交到 dev 分支
+- `master` 分支
+  - `master` 是稳定不改的分支，不会在上面进行代码开发
+  - 在 dev 分支 publish 后会 merge 到 master，同时打对应 tag
+
+## Commit 格式
+
+```
+[{action}] {description}
+```
+
+- `{action}`
+  - `+` 新增功能
+  - `!` 更新或者修复 bug
+  - `-` 移除功能
+- `{description}`
+  - 尽可能详细的描述就好
+
+for example:
+
+- [+] 列表选项新增拖拽功能
+- [!] 修复输入框长按闪烁的问题
+
+## 更多
+
+- 很推荐在提交 PR 前，先在钉钉群里进行讨论，已防止此功能已经有同学在开发了
+- 但是如果是想修复文档和明显代码错误，直接提交 PR 就好

--- a/packages/FR1.0/package.json
+++ b/packages/FR1.0/package.json
@@ -1,0 +1,75 @@
+{
+  "name": "new-form-render",
+  "version": "1.0.0",
+  "description": "通过 JSON Schema 生成标准 Form，常用于自定义搭建配置界面生成",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:alibaba/form-render.git"
+  },
+  "keywords": [
+    "FormRender",
+    "Render",
+    "React",
+    "Json Schema",
+    "Ant Design",
+    "Fusion Design"
+  ],
+  "contributors": [
+    {
+      "name": "Tw93",
+      "email": "tw93@qq.com"
+    },
+    {
+      "name": "mankaiviky",
+      "email": "mankaiviky@163.com"
+    },
+    {
+      "name": "FateRiddle",
+      "email": "fateriddle@gmail.com"
+    }
+  ],
+  "scripts": {
+    "build": "father-build",
+    "prepare": "npm run build",
+    "postpublish": "git push --tags",
+    "beta": "npm publish --tag beta",
+    "prettier": "prettier --write \"**/*.{js,jsx,tsx,ts,less,md,json}\"",
+    "test": "umi-test",
+    "test:coverage": "umi-test --coverage"
+  },
+  "main": "lib/index.js",
+  "module": "dist/index.esm.js",
+  "gitHooks": {
+    "pre-commit": "lint-staged"
+  },
+  "lint-staged": {
+    "*.{js,jsx,less,md,json}": [
+      "prettier --write"
+    ],
+    "*.ts?(x)": [
+      "prettier --parser=typescript --write"
+    ]
+  },
+  "dependencies": {
+    "@ant-design/icons": "^4.0.2",
+    "async-validator": "^3.5.1",
+    "color": "^3.1.2",
+    "moment": "^2.24.0",
+    "nanoid": "^3.1.20",
+    "lodash": "^4.17.20",
+    "rc-color-picker": "^1.2.6",
+    "react-sortable-hoc": "^1.11.0",
+    "tachyons": "^4.12.0",
+    "use-debounce": "^5.2.0"
+  },
+  "peerDependencies": {
+    "@alifd/next": "^1.x",
+    "antd": "^4.x",
+    "react": "^16.8.0 || ^17.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0"
+  },
+  "devDependencies": {
+    "deep-equal": "^2.0.3",
+    "rollup-plugin-commonjs": "^10.1.0"
+  }
+}

--- a/packages/FR1.0/src/App.js
+++ b/packages/FR1.0/src/App.js
@@ -1,0 +1,102 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+import React, { useEffect } from 'react';
+import { flattenSchema } from './utils';
+import FR from './FR';
+import { Ctx, StoreCtx, useSet } from './hooks';
+import { widgets as defaultWidgets } from './widgets/antd';
+import { mapping as defaultMapping } from './mapping';
+import 'tachyons';
+import './index.css';
+
+// 其他入参 watch: {"a.b.c": (value) => { ... }, }
+
+export { useForm } from './useForm';
+
+function App({
+  widgets,
+  mapping,
+  form,
+  beforeFinish,
+  onFinish,
+  displayType,
+  schema,
+  initialData,
+  flatten: _flatten,
+  ...rest
+}) {
+  const {
+    submitData,
+    errorFields,
+    isSubmitting,
+    isValidating,
+    endSubmitting,
+    bindSchema,
+    onItemChange,
+    formData,
+  } = form;
+
+  const [state, setState] = useSet({
+    flatten: {}, // // schema 在内部通用转换成 flatten，一般就一次转换。schema便于书写，flatten便于数据处理
+  });
+
+  const { flatten } = state;
+
+  // window.blog(flatten, form.formData);
+  const store = {
+    flatten,
+    ...form,
+    widgets: { ...defaultWidgets, ...widgets },
+    mapping: { ...defaultMapping, ...mapping },
+    displayType: displayType || 'column',
+    ...rest,
+  };
+
+  useEffect(() => {
+    const newFlatten = _flatten || flattenSchema(schema);
+    bindSchema({ schema, flatten: newFlatten });
+    setState({ flatten: newFlatten });
+  }, [
+    JSON.stringify(_flatten),
+    JSON.stringify(schema),
+    JSON.stringify(formData),
+  ]);
+
+  useEffect(() => {
+    onItemChange('#', initialData);
+  }, [JSON.stringify(initialData)]);
+
+  useEffect(() => {
+    // 如果validation结束，但是submitting开始
+    if (!isValidating && isSubmitting) {
+      if (beforeFinish && typeof beforeFinish === 'function') {
+        Promise.resolve(beforeFinish({ formData: submitData, errorFields }))
+          .then(_ => {
+            Promise.resolve(onFinish({ formData: submitData, errorFields }));
+          })
+          .then(endSubmitting);
+      } else {
+        Promise.resolve(onFinish({ formData: submitData, errorFields })).then(
+          endSubmitting
+        );
+      }
+    }
+  }, [isValidating, isSubmitting]);
+
+  // TODO: Ctx 这层暂时不用，所有都放在StoreCtx，之后性能优化在把一些常量的东西提取出来
+  return (
+    <StoreCtx.Provider value={store}>
+      <Ctx.Provider value={{}}>
+        <div>{'isEditting:' + JSON.stringify(form.isEditing)}</div>
+        <div>{'isValidating:' + JSON.stringify(form.isValidating)}</div>
+        <div>{'isSubmitting:' + JSON.stringify(form.isSubmitting)}</div>
+        <div className="fr-wrapper">
+          <FR />
+        </div>
+      </Ctx.Provider>
+    </StoreCtx.Provider>
+  );
+}
+
+export { createWidget } from './HOC';
+
+export default App;

--- a/packages/FR1.0/src/FR/RenderChildren/RenderList.js
+++ b/packages/FR1.0/src/FR/RenderChildren/RenderList.js
@@ -1,0 +1,374 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
+import React from 'react';
+import FR from '../index';
+import { get } from 'lodash';
+import { useStore, useSet } from '../../hooks';
+import { getDataPath, getKeyFromPath, getDisplayValue } from '../../utils';
+import { Button, Table, Drawer, Space } from 'antd';
+import ArrowUp from '../../components/ArrowUp';
+import ArrowDown from '../../components/ArrowDown';
+import ErrorMessage from '../RenderField/ErrorMessage';
+
+const FIELD_LENGTH = 200;
+
+const RenderList = ({
+  parentId,
+  dataIndex = [],
+  children = [],
+  errorFields,
+}) => {
+  // console.log(parentId, dataIndex, children);
+  const { formData, onItemChange, removeValidation, flatten } = useStore();
+
+  // 计算 list对应的formData
+  const dataPath = getDataPath(parentId, dataIndex);
+  let listData;
+  if (typeof dataPath === 'string') {
+    // TODO: listData会有不少“窟窿”，submit 的时候，listData 需要补齐 or filter
+    listData = get(formData, dataPath);
+  }
+
+  const displayList = Array.isArray(listData) ? listData : [undefined];
+
+  const addItem = () => {
+    const newList = [...displayList, undefined];
+    const newIndex = newList.length - 1;
+    onItemChange(dataPath, newList);
+    return newIndex;
+  };
+
+  const deleteItem = idx => {
+    // TODO: 删除元素的时候，也需要delete相对于的校验信息（errorFields）
+    // remark: 删除时，不存在的item需要补齐，用null
+    const newList = displayList.filter((item, kdx) => kdx !== idx);
+    onItemChange(dataPath, newList);
+    // const itemPath = dataPath + `[${idx}]`; //TODO: 这块有问题啊，idx好像不准
+    removeValidation(dataPath);
+  };
+
+  const moveItemUp = idx => {
+    if (idx === 0) return;
+    const currentItem = displayList[idx];
+    const itemAbove = displayList[idx - 1];
+    const newList = displayList;
+    newList[idx] = itemAbove;
+    newList[idx - 1] = currentItem;
+    onItemChange(dataPath, newList);
+  };
+
+  const moveItemDown = idx => {
+    if (idx >= displayList.length - 1) return;
+    const currentItem = displayList[idx];
+    const itemBelow = displayList[idx + 1];
+    const newList = displayList;
+    newList[idx] = itemBelow;
+    newList[idx + 1] = currentItem;
+    onItemChange(dataPath, newList);
+  };
+
+  const displayProps = {
+    displayList,
+    dataPath,
+    dataIndex,
+    children,
+    deleteItem,
+    addItem,
+    moveItemDown,
+    moveItemUp,
+    listData,
+    flatten,
+    errorFields,
+  };
+
+  // TODO: 还有其他的写法
+  return <CardList {...displayProps} />;
+
+  return <TableList {...displayProps} />;
+};
+
+export default RenderList;
+
+const CardList = ({
+  displayList = [{}],
+  dataPath,
+  dataIndex,
+  children,
+  deleteItem,
+  addItem,
+  moveItemDown,
+  moveItemUp,
+  flatten,
+  errorFields,
+}) => {
+  const [state, setState] = useSet({
+    showDrawer: false,
+    currentIndex: -1,
+  });
+
+  const _infoItem = {
+    schema: { type: 'object', properties: {} },
+    rules: [],
+    children,
+  };
+
+  const { showDrawer, currentIndex } = state;
+
+  const dataSource = displayList.map((item, index) => ({
+    ...item,
+    $idx: index,
+  }));
+
+  const truncatedChildren = children.slice(0, 3); // TODO：允许调整，允许选择使用哪几个child
+
+  const columns = truncatedChildren.map(child => {
+    const item = flatten[child];
+    const schema = (item && item.schema) || {};
+    const _dataIndex = getKeyFromPath(child);
+    return {
+      dataIndex: _dataIndex,
+      title: schema.title,
+      width: FIELD_LENGTH,
+      render: (value, record) => {
+        const childPath = getDataPath(child, [record.$idx]);
+        const errorObj = errorFields.find(item => item.name == childPath) || {};
+        //TODO: 万一error在更深的层，这个办法是find不到的，会展示那一行没有提示。可以整一行加一个红线的方式处理
+        return (
+          <div>
+            <div>{getDisplayValue(value, schema)}</div>
+            {errorObj.error && <ErrorMessage message={errorObj.error} />}
+          </div>
+        );
+      },
+    };
+  });
+
+  columns.push({
+    title: '操作',
+    key: '$action',
+    fixed: 'right',
+    width: 110,
+    render: (value, record, index) => {
+      return (
+        <Space>
+          <a onClick={() => openDrawer(index)}>编辑</a>
+          <a onClick={() => deleteItem(index)}>删除</a>
+          <ArrowUp height={18} width={24} onClick={() => moveItemUp(index)} />
+          <ArrowDown
+            height={18}
+            width={24}
+            onClick={() => moveItemDown(index)}
+          />
+        </Space>
+      );
+    },
+  });
+
+  const openDrawer = index => {
+    setState({
+      showDrawer: true,
+      currentIndex: index,
+    });
+  };
+
+  const closeDrawer = () => {
+    setState({
+      showDrawer: false,
+      currentIndex: -1,
+    });
+  };
+
+  const handleAdd = () => {
+    const newIndex = addItem();
+    openDrawer(newIndex);
+  };
+
+  return (
+    <>
+      <div className="w-100 mb2 tr">
+        <Button type="primary" size="small" onClick={handleAdd}>
+          新增
+        </Button>
+      </div>
+      <Drawer
+        width="500"
+        title="编辑"
+        placement="right"
+        onClose={closeDrawer}
+        visible={showDrawer}
+      >
+        <FR
+          // id={children[currentIndex]}
+          _item={_infoItem}
+          dataIndex={[...dataIndex, currentIndex]}
+        />
+      </Drawer>
+      <Table
+        columns={columns}
+        dataSource={dataSource}
+        rowClassName={(record, idx) => {
+          // console.log(errorFields, `${dataPath}[${idx}]`, 'errorsadf');
+          const hasError = errorFields.find(
+            item => item.name.indexOf(`${dataPath}[${idx}]`) > -1
+          );
+          return hasError ? 'fr-row-error' : '';
+        }}
+        rowKey="$idx"
+        size="small"
+        scroll={{ x: children.length * FIELD_LENGTH }}
+        pagination={{ size: 'small', hideOnSinglePage: true }}
+      />
+    </>
+  );
+};
+
+const TableList = ({
+  displayList = [{}],
+  dataIndex,
+  children,
+  deleteItem,
+  addItem,
+  flatten,
+}) => {
+  const dataSource = displayList.map((item, idx) => {
+    return { index: idx };
+  });
+
+  const columns = children.map(child => {
+    const item = flatten[child];
+    const schema = (item && item.schema) || {};
+    return {
+      dataIndex: child,
+      title: schema.title,
+      width: FIELD_LENGTH,
+      render: (value, record, index) => {
+        // Check: record.index 似乎是antd自己会给的，不错哦
+        const childIndex = [...dataIndex, record.index];
+        return (
+          <FR
+            hideTitle={true}
+            hideValidation={true}
+            key={index.toString()}
+            id={child}
+            dataIndex={childIndex}
+          />
+        );
+      },
+    };
+  });
+
+  columns.push({
+    title: '操作',
+    key: '$action',
+    fixed: 'right',
+    width: 120,
+    render: (value, record, index) => {
+      return <a onClick={() => deleteItem(index)}>删除</a>;
+    },
+  });
+
+  return (
+    <>
+      <div className="w-100 mb2 tr">
+        <Button type="primary" size="small" onClick={addItem}>
+          新增
+        </Button>
+      </div>
+      <Table
+        columns={columns}
+        dataSource={dataSource}
+        rowKey="index"
+        size="small"
+        scroll={{ x: children.length * FIELD_LENGTH }}
+        pagination={{ size: 'small', hideOnSinglePage: true }}
+      />
+    </>
+  );
+};
+
+// TODO: 1. 展示有问题, 需要去具体算text的内容 2. 校验有问题，没有展开的项没有被校验到
+// const ExpandList = ({
+//   displayList = [{}],
+//   dataIndex,
+//   children,
+//   deleteItem,
+//   addItem,
+//   listData = [],
+//   childrenSchema,
+// }) => {
+//   const dataSource = displayList.map((item, idx) => {
+//     const data = listData[idx] || {};
+//     return { ...data, index: idx };
+//   });
+
+//   const columns = Object.keys(childrenSchema).map(key => {
+//     const item = childrenSchema[key];
+//     return {
+//       dataIndex: key,
+//       title: item.title,
+//       render: value => value || '-', // TODO: something
+//     };
+//   });
+
+//   columns.push({
+//     title: '操作',
+//     key: '$action',
+//     render: (record, idx) => {
+//       return <a onClick={() => deleteItem(idx)}>Delete</a>;
+//     },
+//   });
+
+//   return (
+//     <>
+//       <Table
+//         columns={columns}
+//         dataSource={dataSource}
+//         // defaultExpandAllRows
+//         rowKey="index"
+//         expandable={{
+//           expandedRowRender: (record, idx) => {
+//             const childIndex = [...dataIndex, idx];
+//             return (
+//               <li className={`w-100`}>
+//                 {children.map((child, idx2) => {
+//                   return (
+//                     <FR
+//                       key={idx2.toString()}
+//                       id={child}
+//                       dataIndex={childIndex}
+//                     />
+//                   );
+//                 })}
+//               </li>
+//             );
+//           },
+//         }}
+//       />
+//       <div className="w-100">
+//         <Button onClick={addItem}>addItem</Button>
+//       </div>
+//     </>
+//   );
+
+//   return (
+//     <ul className="flex flex-wrap pl0 list">
+//       {(displayList || []).map((item, idx) => {
+//         const childIndex = [...dataIndex, idx];
+//         return (
+//           <li key={idx.toString()} className={`w-100`}>
+//             {children.map((child, idx2) => {
+//               return (
+//                 <FR key={idx2.toString()} id={child} dataIndex={childIndex} />
+//               );
+//             })}
+//             {Array.isArray(displayList) && displayList.length > 1 && (
+//               <Button onClick={() => deleteItem(idx)}>delete</Button>
+//             )}
+//           </li>
+//         );
+//       })}
+//       <div className="w-100">
+//         <Button onClick={addItem}>addItem</Button>
+//       </div>
+//     </ul>
+//   );
+// };

--- a/packages/FR1.0/src/FR/RenderChildren/RenderObject.js
+++ b/packages/FR1.0/src/FR/RenderChildren/RenderObject.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import FR from '../index';
+
+// TODO: nanoId 好像没啥用
+const RenderObject = ({ children = [], dataIndex = [] }) => {
+  return (
+    <>
+      {children.map((child, i) => {
+        const FRProps = {
+          id: child,
+          dataIndex,
+        };
+        return <FR key={i.toString()} {...FRProps} />;
+      })}
+    </>
+  );
+};
+
+export default RenderObject;

--- a/packages/FR1.0/src/FR/RenderField/ErrorMessage.css
+++ b/packages/FR1.0/src/FR/RenderField/ErrorMessage.css
@@ -1,0 +1,7 @@
+.error-message {
+  color: #ff4d4f;
+  min-height: 24px;
+  font-size: 14px;
+  line-height: 1.5715;
+  transition: color 0.3s cubic-bezier(0.215, 0.61, 0.355, 1);
+}

--- a/packages/FR1.0/src/FR/RenderField/ErrorMessage.js
+++ b/packages/FR1.0/src/FR/RenderField/ErrorMessage.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import './ErrorMessage.css';
+
+const ErrorMessage = ({ message }) => {
+  return <div className="error-message">{message}</div>;
+};
+
+export default ErrorMessage;

--- a/packages/FR1.0/src/FR/RenderField/ExtendedWidget.js
+++ b/packages/FR1.0/src/FR/RenderField/ExtendedWidget.js
@@ -1,0 +1,50 @@
+import React, { useMemo } from 'react';
+import { getWidgetName, extraSchemaList } from '../../mapping';
+import { defaultWidgetNameList } from '../../widgets/antd';
+import { useStore } from '../../hooks';
+import { transformProps } from '../../HOC';
+
+const ExtendedWidget = ({
+  title,
+  schema,
+  onChange,
+  value,
+  children,
+  onItemChange,
+}) => {
+  const { widgets, mapping } = useStore();
+
+  // TODO: 计算是哪个widget，需要优化
+  let widgetName = getWidgetName(schema, mapping);
+  let Widget = widgets[widgetName];
+  const customName = schema['ui:widget'];
+  if (customName && widgets[customName]) {
+    Widget = widgets[customName];
+    widgetName = customName;
+  }
+
+  const extraSchema = extraSchemaList[widgetName];
+
+  const widgetProps = {
+    schema: { ...schema, ...extraSchema },
+    onChange,
+    value,
+    children,
+  };
+
+  if (title) {
+    widgetProps.title = title;
+  }
+
+  // 避免传组件不接受的props，按情况传多余的props
+  const isExternalWidget = defaultWidgetNameList.indexOf(widgetName) === -1; // 是否是外部组件
+  if (isExternalWidget) {
+    widgetProps.onItemChange = onItemChange; // 只给外部组件提供，默认的组件都是简单组件，不需要，多余的props会warning，很烦
+  }
+
+  const finalProps = transformProps(widgetProps);
+
+  return <Widget {...finalProps} />;
+};
+
+export default ExtendedWidget;

--- a/packages/FR1.0/src/FR/RenderField/Title.js
+++ b/packages/FR1.0/src/FR/RenderField/Title.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import { useStore } from '../../hooks';
+import { isCheckBoxType } from '../../utils'
+
+const Title = ({ labelClass, labelStyle, schema }) => {
+  const { showDescIcon, displayType } = useStore();
+  const { title, description, required, type } = schema;
+  const isObjType = type === 'object';
+
+  return (
+    <div className={labelClass} style={labelStyle}>
+      <label
+        className={`fr-label-title ${
+          isCheckBoxType(schema) || displayType === 'column'
+            ? 'no-colon'
+            : ''
+        }`} // checkbox不带冒号
+        title={title}
+      >
+        {required === true && <span className="fr-label-required"> *</span>}
+        <span
+          className={`${isObjType ? 'b' : ''} ${
+            displayType === 'column' ? 'flex-none' : ''
+          }`}
+        >
+          {title}
+        </span>
+        {description &&
+          (showDescIcon ? (
+            <span className="fr-tooltip-toggle" aria-label={description}>
+              <i className="fr-tooltip-icon" />
+              <div className="fr-tooltip-container">
+                <i className="fr-tooltip-triangle" />
+                {description}
+              </div>
+            </span>
+          ) : (
+            <span className="fr-desc ml2">(&nbsp;{description}&nbsp;)</span>
+          ))}
+      </label>
+    </div>
+  );
+};
+
+export default Title;

--- a/packages/FR1.0/src/FR/RenderField/index.js
+++ b/packages/FR1.0/src/FR/RenderField/index.js
@@ -1,0 +1,198 @@
+import React, { useEffect, useRef } from 'react';
+import { useStore } from '../../hooks';
+import useDebouncedCallback from 'use-debounce/lib/useDebouncedCallback';
+import {
+  getDataPath,
+  getValueByPath,
+  isCheckBoxType,
+  isObjType,
+  schemaContainsExpression,
+  parseAllExpression,
+  parseSingleExpression,
+  isExpression,
+  isObject,
+  clone,
+} from '../../utils';
+import ErrorMessage from './ErrorMessage';
+import FieldTitle from './Title';
+import ExtendedWidget from './ExtendedWidget';
+
+// TODO: 之后不要直接用get，收口到一个内部方法getValue，便于全局 ctrl + f 查找
+const RenderField = ({
+  $id,
+  dataIndex,
+  item,
+  labelClass,
+  labelStyle,
+  contentClass,
+  hasChildren,
+  children,
+  errorFields = [],
+  hideTitle,
+  hideValidation,
+}) => {
+  const { schema } = item;
+  const {
+    onItemChange,
+    formData,
+    displayType,
+    isEditing,
+    setEditing,
+    extend,
+  } = useStore();
+
+  const snapShot = useRef();
+
+  // 计算数据的真实路径，bind字段会影响
+  let dataPath = getDataPath($id, dataIndex);
+  // TODO: bind 允许bind数组，如果是bind数组，需要更多的处理。暂时只支持bind单个
+  // const isMultiPaths =
+  //   Array.isArray(schema.bind) &&
+  //   schema.bind.every(item => typeof item === 'string');
+  if (schema && schema.bind) {
+    if (typeof schema.bind === 'string') {
+      dataPath = getDataPath(schema.bind, dataIndex);
+    }
+    // else if (isMultiPaths) {
+    //   dataPath = schema.bind.map(b => getDataPath(b, dataIndex));
+    // }
+  }
+
+  // 解析schema
+
+  let _schema = clone(schema); // TODO: 用deepClone，函数啥的才能正常copy，但是deepClone的代价是不是有点大，是否应该让用户避免schema里写函数
+  let _rules = [...item.rules];
+
+  // 节流部分逻辑，编辑时不执行
+  if (isEditing && snapShot.current) {
+    _schema = snapShot.current;
+  } else {
+    if (schemaContainsExpression(_schema)) {
+      _schema = parseAllExpression(_schema, formData, dataPath);
+    }
+    snapShot.current = _schema;
+
+    _rules = _rules.map(rule => {
+      // if (rule.required) debugger;
+      const newRule = {};
+      Object.keys(rule).forEach(key => {
+        const needParse = isExpression(rule[key]);
+        newRule[key] = needParse
+          ? parseSingleExpression(rule[key], formData, dataPath)
+          : rule[key];
+      });
+      return newRule;
+    });
+  }
+
+  const errObj = errorFields.find(err => err.name === dataPath);
+  const errList = errObj && errObj.error;
+  const errorMessage = Array.isArray(errList) ? errList[0] : undefined;
+
+  // dataPath 有3种情况："#"、"a.b.c"、["a.b.c", "e.d.f"]
+  const getValue = () => {
+    // if (isMultiPaths) {
+    //   return dataPath.map(path => getValueByPath(formData, path));
+    // }
+    return getValueByPath(formData, dataPath);
+  };
+
+  // 从全局 formData 获取 value
+  const _value = getValue(dataPath, formData);
+
+  // check: 由于是专门针对checkbox的，目前只好写这里
+  let _labelStyle = labelStyle;
+  if (isCheckBoxType(_schema)) {
+    _labelStyle = { flexGrow: 1 };
+  }
+
+  let contentStyle = {};
+  if (isCheckBoxType(_schema) && displayType === 'row') {
+    contentStyle.marginLeft = labelStyle.width;
+  }
+
+  const outMapProps = isObject(extend) && extend[dataPath];
+  const _outMapProps =
+    typeof outMapProps === 'function' ? outMapProps : () => {};
+
+  const debouncedSetEditing = useDebouncedCallback(setEditing, 350);
+
+  // TODO: 优化一下，只有touch还是false的时候，setTouched
+  const onChange = value => {
+    // 开始编辑，节流
+    setEditing(true);
+    debouncedSetEditing.callback(false);
+    if (typeof dataPath === 'string') {
+      onItemChange(dataPath, value);
+    }
+  };
+
+  const titleProps = {
+    labelClass,
+    labelStyle: _labelStyle,
+    schema: _schema,
+  };
+
+  const placeholderTitleProps = {
+    className: labelClass,
+    style: _labelStyle,
+  };
+
+  const _showTitle = !hideTitle && !!_schema.title;
+
+  const _hideValidation =
+    isObjType(_schema) || (hideValidation && !errorMessage);
+
+  const widgetProps = {
+    schema: _schema,
+    onChange,
+    value: _value,
+    onItemChange,
+  };
+
+  if (_outMapProps) {
+    widgetProps.mapProps = _outMapProps;
+  }
+
+  widgetProps.children = hasChildren
+    ? children
+    : isCheckBoxType(_schema)
+    ? _schema.title
+    : null;
+
+  // checkbox必须单独处理，布局太不同了
+  if (isCheckBoxType(_schema)) {
+    return (
+      <>
+        {_showTitle && <div {...placeholderTitleProps} />}
+        <div className={contentClass} style={contentStyle}>
+          <ExtendedWidget {...widgetProps} />
+          {_hideValidation ? null : <ErrorMessage message={errorMessage} />}
+        </div>
+      </>
+    );
+  }
+
+  const titleElement = _showTitle && <FieldTitle {...titleProps} />;
+
+  if (isObjType(_schema)) {
+    return (
+      <div className={contentClass} style={contentStyle}>
+        <ExtendedWidget {...widgetProps} title={titleElement} />
+        {_hideValidation ? null : <ErrorMessage message={errorMessage} />}
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {titleElement}
+      <div className={contentClass} style={contentStyle}>
+        <ExtendedWidget {...widgetProps} />
+        {_hideValidation ? null : <ErrorMessage message={errorMessage} />}
+      </div>
+    </>
+  );
+};
+
+export default RenderField;

--- a/packages/FR1.0/src/FR/index.js
+++ b/packages/FR1.0/src/FR/index.js
@@ -1,0 +1,181 @@
+import React from 'react';
+import RenderList from './RenderChildren/RenderList';
+import RenderObject from './RenderChildren/RenderObject';
+import RenderField from './RenderField';
+import { useStore } from '../hooks';
+import {
+  isLooselyNumber,
+  isCssLength,
+  getParentProps,
+  isListType,
+  isCheckBoxType,
+} from '../utils';
+
+// rest: 允许在每层FR重新定义全局props，覆盖
+const FR = ({
+  id = '#',
+  _item, // 如果直接传了item，就不用id去取item, 暂时是内部属性，不外用
+  dataIndex = [], // 数据来源是数组的第几个index，上层每有一个list，就push一个index
+  hideTitle = false,
+  hideValidation = false,
+  ...rest
+}) => {
+  const {
+    displayType,
+    column,
+    flatten,
+    errorFields,
+    labelWidth,
+    isEditing,
+  } = useStore();
+  const _displayType = rest.displayType || displayType || 'column';
+  const item = _item ? _item : flatten[id];
+  if (!item) return null;
+
+  const { schema } = item;
+  const isObjType = schema.type === 'object'; // TODO: 这个好像太笼统了，万一不是这样呢
+  const isList = isListType(schema);
+  const isComplex = isObjType || isList;
+  const isCheckBox = isCheckBoxType(schema);
+  const width = schema['ui:width'];
+  let containerClass = `fr-field ${
+    _displayType === 'inline' ? '' : 'w-100'
+  } flex`;
+  let labelClass = `fr-label`;
+  let contentClass = `fr-content`;
+  // common classNames dispite row or column
+  switch (schema.type) {
+    case 'object':
+      if (isObjType) {
+        if (schema.title) {
+          labelClass += ' fr-label-object';
+        }
+        containerClass += ' fr-field-object';
+      }
+      break;
+    case 'array':
+      // list 有两种展示形式！
+      if (isList) {
+        if (schema.title) {
+          labelClass += ' fr-label-list';
+        }
+        containerClass += ' fr-field-column';
+      }
+      break;
+    case 'boolean':
+      if (isCheckBox) {
+        contentClass += ' fr-content-column'; // checkbox高度短，需要居中对齐
+        containerClass += ` flex ${
+          _displayType === 'column' ? 'flex-column' : ''
+        }`;
+      }
+      break;
+    default:
+  }
+  // column specific className
+  if (!isComplex && !isCheckBox) {
+    if (_displayType === 'column') {
+      containerClass += ' flex-column';
+      labelClass += ' fr-label-column';
+      contentClass += ' fr-content-column';
+      switch (schema.type) {
+        case 'object':
+          break;
+        case 'array':
+          if (schema.title && !schema.enum) {
+            // labelClass += ' b mb2';
+          }
+          break;
+        case 'boolean':
+          break;
+        default:
+      }
+    } else if (_displayType === 'row') {
+      // row specific className
+      containerClass += '';
+      labelClass += ' fr-label-row';
+      contentClass += ' fr-content-row';
+      if (!isObjType && !isCheckBox) {
+        labelClass += ' flex-shrink-0 fr-label-row';
+        contentClass += ' flex-grow-1 relative';
+      }
+    }
+  }
+
+  // style part
+  let columnStyle = {};
+  if (!isObjType) {
+    if (width) {
+      columnStyle = {
+        width,
+        paddingRight: '12px',
+      };
+    } else if (column > 1) {
+      columnStyle = {
+        width: `calc(100% /${column})`,
+        paddingRight: '12px',
+      };
+    }
+  }
+
+  // 真正有效的label宽度需要从现在所在item开始一直往上回溯（设计成了继承关系），找到的第一个有值的 ui:labelWidth
+  const effectiveLabelWidth =
+    getParentProps('ui:labelWidth', id, flatten) || labelWidth;
+  const _labelWidth = isLooselyNumber(effectiveLabelWidth)
+    ? Number(effectiveLabelWidth)
+    : isCssLength(effectiveLabelWidth)
+    ? effectiveLabelWidth
+    : 110; // 默认是 110px 的长度
+
+  let labelStyle = { width: _labelWidth };
+  if (isComplex || _displayType === 'column') {
+    labelStyle = { flexGrow: 1 };
+  }
+
+  const hasChildren = item.children && item.children.length > 0;
+
+  const fieldProps = {
+    $id: id,
+    dataIndex,
+    item,
+    labelClass,
+    labelStyle,
+    contentClass,
+    errorFields,
+    hasChildren,
+    // 层级间可使用的字段
+    hideTitle,
+    hideValidation,
+  };
+
+  const objChildren = hasChildren ? (
+    <ul className={`flex flex-wrap pl0`}>
+      <RenderObject dataIndex={dataIndex} errorFields={errorFields}>
+        {item.children}
+      </RenderObject>
+    </ul>
+  ) : null;
+
+  const listChildren = hasChildren ? (
+    <RenderList parentId={id} dataIndex={dataIndex} errorFields={errorFields}>
+      {item.children}
+    </RenderList>
+  ) : null;
+
+  // TODO: list 也要算进去
+  return (
+    <div style={columnStyle} className={containerClass}>
+      <RenderField {...fieldProps}>
+        {isObjType && objChildren}
+        {isList && listChildren}
+      </RenderField>
+    </div>
+  );
+};
+
+export default FR;
+
+// const FieldWrapper = ({ children, ...rest }) => {
+//   const fieldProps = { ...rest };
+//   return React.cloneElement(children, fieldProps);
+// };

--- a/packages/FR1.0/src/HOC.js
+++ b/packages/FR1.0/src/HOC.js
@@ -1,0 +1,66 @@
+import { defaultGetValueFromEvent } from './utils';
+// TODO: props传入的值，之后要改造
+// mention: createWidget 设计的构架，保证了可以多次使用套壳，而不会互相影响。内部使用了一遍用于解析schema上的字段trigger, valuePropName。外部生成自定义组件的时候还可以再套一层，用于解析 propsMap
+export const createWidget = (mapProps, extraSchema) => Component => props => {
+  const { schema, ...rest } = props;
+  const _schema = { ...schema, ...extraSchema };
+
+  const propsMap =
+    typeof mapProps === 'function'
+      ? mapProps({
+          schema: _schema,
+          ...rest,
+        })
+      : {};
+
+  const _props = {
+    schema: _schema,
+    ...rest,
+    ...propsMap, //TODO: propsMap 需要验证一下是否为object
+  };
+
+  const finalProps = transformProps(_props);
+
+  return <Component {...finalProps} />;
+};
+
+export const transformProps = props => {
+  const { onChange, value, schema: ownSchema, ...rest } = props;
+  const schema = { ...ownSchema };
+  const { trigger, valuePropName } = schema || {};
+  const controlProps = {};
+  let _valuePropName = 'value';
+  if (valuePropName && typeof valuePropName === 'string') {
+    _valuePropName = valuePropName;
+    controlProps[valuePropName] = value;
+  } else {
+    controlProps.value = value;
+  }
+  const _onChange = (...args) => {
+    const newValue = defaultGetValueFromEvent(_valuePropName, ...args);
+    onChange(newValue);
+  };
+  if (trigger && typeof trigger === 'string') {
+    controlProps[trigger] = _onChange;
+  } else {
+    controlProps.onChange = _onChange;
+  }
+
+  // TODO: 之后 ui:xx 会舍去
+  const usefulPropsFromSchema = {
+    disabled: schema.disabled || schema['ui:disabled'],
+    readOnly: schema.readOnly || schema['ui:readonly'],
+    hidden: schema.hidden || schema['ui:hidden'],
+    // $options: schema.options || schema['ui:options'],
+    // width: schema.width || schema['ui:width'],
+  };
+
+  const _props = {
+    ...controlProps,
+    schema,
+    ...usefulPropsFromSchema,
+    ...rest,
+  };
+
+  return _props;
+};

--- a/packages/FR1.0/src/basic.json
+++ b/packages/FR1.0/src/basic.json
@@ -1,0 +1,223 @@
+{
+  "type": "object",
+  "properties": {
+    "dateRangeExample": {
+      "title": "日期范围",
+      "bind": ["startDate", "endDate"],
+      "type": "range",
+      "format": "date",
+      "required": true,
+      "ui:disabled": "{{formData.percentage == 10}}"
+    },
+    "list": {
+      "title": "对象数组",
+      "bind": "someList",
+      "description": "对象数组嵌套功能",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "objectName": {
+            "title": "对象",
+            "description": "这是一个对象类型",
+            "type": "object",
+            "properties": {
+              "inputName": {
+                "title": "简单输入框",
+                "type": "string"
+              }
+            }
+          },
+          "userName": {
+            "bind": false,
+            "title": "User Name",
+            "type": "string",
+            "rules": [
+              {
+                "min": 5,
+                "message": "长度需要大于5"
+              },
+              {
+                "max": 12
+              }
+            ]
+          },
+          "selectName": {
+            "title": "单选",
+            "type": "string",
+            "enum": ["a", "b", "c"],
+            "enumNames": ["早", "中", "晚"],
+            "required": true
+          },
+          "checkboxName": {
+            "title": "是否判断",
+            "type": "boolean",
+            "valuePropName": "checked"
+          }
+        }
+      }
+    },
+    "percentage": {
+      "title": "百分比",
+      "type": "number",
+      "required": true,
+      "ui:widget": "percent",
+      "rules": [
+        {
+          "min": 10,
+          "message": "长度需要大于10"
+        },
+        {
+          "max": 80
+        }
+      ]
+    },
+    "AllString": {
+      "title": "string类",
+      "type": "object",
+      "properties": {
+        "objectName": {
+          "title": "对象",
+          "description": "这是一个对象类型",
+          "type": "object",
+          "properties": {
+            "inputName": {
+              "title": "简单输入框",
+              "type": "string"
+            }
+          }
+        },
+        "input": {
+          "title": "简单输入框",
+          "bind": "a.b.c",
+          "type": "string",
+          "ui:disabled": "{{rootValue.d === '1'}}",
+          "ui:options": {
+            "placeholder": "haha"
+          },
+          "required": "{{rootValue.d === '1'}}"
+        },
+        "textarea": {
+          "bind": "a.b.d",
+          "title": "简单文本编辑框",
+          "type": "string",
+          "format": "textarea"
+        },
+        "color": {
+          "bind": "color",
+          "title": "颜色选择",
+          "type": "string",
+          "format": "color"
+        },
+        "date": {
+          "title": "日期选择",
+          "type": "string",
+          "format": "date"
+        },
+        "image": {
+          "bind": false,
+          "title": "图片展示",
+          "type": "string",
+          "format": "image"
+        },
+        "uploader": {
+          "title": "上传文件",
+          "type": "string",
+          "format": "upload",
+          "ui:options": {
+            "action": "https://www.mocky.io/v2/5cc8019d300000980a055e76"
+          }
+        }
+      }
+    },
+    "allNumber": {
+      "title": "number类",
+      "type": "object",
+      "properties": {
+        "number1": {
+          "title": "数字输入框",
+          "description": "1 - 1000",
+          "type": "number",
+          "min": 1,
+          "max": 1000
+        },
+        "number2": {
+          "title": "带滑动条",
+          "type": "number",
+          "ui:widget": "slider"
+        }
+      }
+    },
+    "allBoolean": {
+      "title": "boolean类",
+      "type": "object",
+      "properties": {
+        "checkbox": {
+          "title": "是否通过",
+          "type": "boolean",
+          "default": true
+        },
+        "switch": {
+          "title": "开关控制",
+          "type": "boolean",
+          "ui:widget": "switch"
+        }
+      }
+    },
+    "allRange": {
+      "title": "range类",
+      "type": "object",
+      "properties": {
+        "dateRange": {
+          "title": "日期范围",
+          "type": "range",
+          "format": "dateTime",
+          "ui:options": {
+            "placeholder": ["开始时间", "结束时间"]
+          }
+        }
+      }
+    },
+    "allEnum": {
+      "title": "选择类",
+      "type": "object",
+      "properties": {
+        "select": {
+          "title": "单选",
+          "type": "string",
+          "enum": ["a", "b", "c"],
+          "enumNames": ["早", "中", "晚"]
+        },
+        "radio": {
+          "title": "单选",
+          "type": "string",
+          "enum": ["a", "b", "c"],
+          "enumNames": ["早", "中", "晚"],
+          "ui:widget": "radio"
+        },
+        "multiSelect": {
+          "title": "多选",
+          "description": "下拉多选",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "enum": ["A", "B", "C", "D"],
+          "enumNames": ["杭州", "武汉", "湖州", "贵阳"],
+          "ui:widget": "multiSelect"
+        },
+        "boxes": {
+          "title": "多选",
+          "description": "checkbox",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "enum": ["A", "B", "C", "D"],
+          "enumNames": ["杭州", "武汉", "湖州", "贵阳"]
+        }
+      }
+    }
+  },
+  "required": []
+}

--- a/packages/FR1.0/src/basic1.json
+++ b/packages/FR1.0/src/basic1.json
@@ -1,0 +1,3752 @@
+{
+  "properties": {
+    "crowd": {
+      "properties": {
+        "upfIdType": {
+          "title": "圈人平台ID类型",
+          "description": "",
+          "type": "string",
+          "enum": ["1", "2"],
+          "enumNames": ["白名单", "黑名单"],
+          "ui:width": "50%"
+        },
+        "upfIdList": {
+          "title": "圈人平台ID",
+          "description": "",
+          "type": "string",
+          "ui:width": "50%"
+        },
+        "realNameChecked": {
+          "title": "实名可见",
+          "description": "",
+          "type": "boolean"
+        },
+        "realNameIdentityChecked": {
+          "title": "身份证认证",
+          "description": "",
+          "type": "boolean"
+        },
+        "vipLevels": {
+          "title": "飞猪会员身份",
+          "description": "",
+          "type": "array",
+          "items": { "type": "string" },
+          "enum": ["1", "101", "2", "3"],
+          "enumNames": ["F1(原F1)", "F2(新F1+)", "F3(原F2)", "F4(原F3)"]
+        },
+        "bbVipCheck": {
+          "title": "88vip认证",
+          "description": "",
+          "type": "boolean"
+        },
+        "dreamCouponLotteryCheck": {
+          "title": "99梦想券抽奖专用",
+          "description": "",
+          "type": "boolean",
+          "ui:hidden": "@['LOTTERY','AWARD'].indexOf(formData.wfCommonInfo.productCode)===-1"
+        },
+        "saveMoneyCardCheck": {
+          "title": "飞猪省钱卡用户",
+          "description": "",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "required": [],
+      "title": "人群限制",
+      "name": "crowd"
+    },
+    "limit": {
+      "properties": {
+        "totalLimitCount": {
+          "title": "库存总数",
+          "description": "保底库存最少X个",
+          "type": "string",
+          "pattern": "^([0-9])+$",
+          "ui:width": "33%"
+        },
+        "addAllCount": {
+          "title": "已补充总库存",
+          "description": "",
+          "type": "string",
+          "ui:hidden": "hasAddItems == '1'",
+          "ui:disabled": true,
+          "ui:width": "33%"
+        },
+        "totalLimitId": {
+          "title": "库存限制ID",
+          "description": "",
+          "type": "string",
+          "pattern": "^([1-9]\\d*|0)$",
+          "ui:hidden": true
+        },
+        "surplusCount": {
+          "title": "剩余有效库存",
+          "description": "",
+          "type": "string",
+          "ui:disabled": true,
+          "ui:width": "33%"
+        },
+        "noActiveAllCount": {
+          "title": "未生效总库存",
+          "description": "",
+          "type": "string",
+          "ui:hidden": "hasAddItems == '1'",
+          "ui:disabled": true,
+          "ui:width": "33%"
+        },
+        "userLimitTotal": {
+          "title": "单用户总参与次数",
+          "description": "用户在该活动总共可领取数量",
+          "type": "string",
+          "pattern": "^([1-9]\\d*)$",
+          "ui:width": "33%"
+        },
+        "showAdvancedSetting": {
+          "title": "高级配置展开显示（收起不影响功能）",
+          "description": "",
+          "type": "boolean",
+          "ui:hidden": "{{formData.integralCertificateCouponUseValidity && formData.integralCertificateCouponUseValidity.sellCouponFlag===true}}"
+        },
+        "userLimitDay": {
+          "title": "单用户每天参与次数",
+          "description": "用户在该活动每天可领取数量",
+          "type": "string",
+          "pattern": "^([1-9]\\d*)$",
+          "ui:hidden": "showAdvancedSetting==false",
+          "ui:width": "33%"
+        },
+        "userLimitWeek": {
+          "title": "单用户每周参与次数",
+          "description": "用户在该活动每周可领取数量",
+          "type": "string",
+          "pattern": "^([1-9]\\d*)$",
+          "ui:hidden": "showAdvancedSetting==false",
+          "ui:width": "33%"
+        },
+        "userLimitNaturalMonth": {
+          "title": "单用户自然月参与次数",
+          "description": "按自然月限制，非30天周期",
+          "type": "string",
+          "pattern": "^([1-9]\\d*)$",
+          "ui:hidden": "showAdvancedSetting==false",
+          "ui:width": "33%"
+        },
+        "limitDay": {
+          "title": "活动每天可被参与的次数（慎重）",
+          "description": "该活动每天可被领取的数量",
+          "type": "string",
+          "pattern": "^([1-9]\\d*)$",
+          "ui:hidden": "showAdvancedSetting==false",
+          "ui:width": "33%"
+        },
+        "userWinningLimitTotal": {
+          "title": "单用户总可中奖次数",
+          "description": "",
+          "type": "string",
+          "pattern": "^([1-9]\\d*|0)$",
+          "ui:hidden": true,
+          "ui:width": "33%"
+        },
+        "userWinningLimitDay": {
+          "title": "单用户每天可中奖次数",
+          "description": "",
+          "type": "string",
+          "pattern": "^([1-9]\\d*|0)$",
+          "ui:hidden": true,
+          "ui:width": "33%"
+        },
+        "userWinningLimitWeek": {
+          "title": "单用户每周可中奖次数",
+          "description": "",
+          "type": "string",
+          "pattern": "^([1-9]\\d*|0)$",
+          "ui:hidden": true,
+          "ui:width": "33%"
+        },
+        "latour2SendFliggyPackage": {
+          "title": "拉菲发飞猪礼包",
+          "description": "",
+          "type": "string",
+          "enum": ["0", "1"],
+          "enumNames": ["否", "是"],
+          "ui:hidden": true,
+          "ui:width": "50%"
+        },
+        "hasAddItems": {
+          "title": "是否添加了添加库存的item",
+          "description": "",
+          "type": "string",
+          "default": "1",
+          "ui:hidden": true
+        },
+        "groupAddLimitText": {
+          "title": "定时添加活动库存",
+          "description": "",
+          "type": "string",
+          "ui:widget": "text",
+          "ui:hidden": "showAdvancedSetting == false"
+        },
+        "incrInventoryItems": {
+          "minItems": 0,
+          "maxItems": 30,
+          "type": "array",
+          "items": {
+            "properties": {
+              "addTime": {
+                "title": "补充时间",
+                "description": "",
+                "type": "string",
+                "ui:widget": "date",
+                "ui:disabled": false,
+                "ui:width": "40%"
+              },
+              "addCount": {
+                "title": "补充数量",
+                "description": "",
+                "type": "string",
+                "pattern": "^([1-9]\\d*|0)$",
+                "ui:disabled": false,
+                "ui:width": "30%"
+              },
+              "validCount": {
+                "title": "已生效数量",
+                "description": "",
+                "type": "string",
+                "pattern": "^([1-9]\\d*|0)$",
+                "ui:disabled": true,
+                "ui:width": "30%"
+              },
+              "taskId": {
+                "title": "执行添加库存任务的Id",
+                "description": "",
+                "type": "string",
+                "ui:hidden": true
+              },
+              "itemId": {
+                "title": "补充库存的记录Id",
+                "description": "",
+                "type": "string",
+                "ui:hidden": true
+              }
+            },
+            "type": "object",
+            "required": ["addTime", "addCount"],
+            "title": "设置定时补充库存",
+            "name": "limitAddItem"
+          },
+          "ui:options": { "foldable": true },
+          "ui:hidden": "showAdvancedSetting==false"
+        }
+      },
+      "type": "object",
+      "required": [
+        "totalLimitCount",
+        "userLimitTotal",
+        "userWinningLimitTotal"
+      ],
+      "title": "参与次数限制",
+      "name": "limit"
+    },
+    "prizeGroupConfigList": {
+      "properties": {
+        "prizeGroupList": {
+          "minItems": 1,
+          "maxItems": 8,
+          "uniqueItems": "name",
+          "type": "array",
+          "items": {
+            "properties": {
+              "name": {
+                "title": "奖品组名称",
+                "description": "",
+                "type": "string",
+                "maxLength": 16,
+                "minLength": 1
+              },
+              "lotteryProbability": {
+                "title": "奖品组中奖概率",
+                "description": "后面输入框输小数",
+                "type": "number",
+                "step": "{{1/formData.lotteryConfig.digit}}",
+                "max": 1,
+                "ui:widget": "slider",
+                "ui:hidden": true
+              },
+              "groupId": {
+                "title": "奖品组ID",
+                "description": "",
+                "type": "string",
+                "maxLength": 16,
+                "minLength": 1,
+                "ui:hidden": true
+              },
+              "groupIdVO": {
+                "title": "奖品组ID",
+                "description": "新建为-1，保存后能查看正确奖品组id",
+                "type": "string",
+                "maxLength": 16,
+                "minLength": 1,
+                "ui:disabled": true
+              },
+              "inventoryId": {
+                "title": "库存ID",
+                "description": "",
+                "type": "string",
+                "maxLength": 16,
+                "minLength": 1,
+                "ui:hidden": true
+              },
+              "inventoryLimit": {
+                "title": "库存限制",
+                "description": "",
+                "type": "string",
+                "maxLength": 16,
+                "minLength": 1,
+                "pattern": "^([0-9])+$",
+                "ui:width": "50%"
+              },
+              "groupAddAllCount": {
+                "title": "奖品组已补充总库存",
+                "description": "",
+                "type": "string",
+                "ui:hidden": "groupHasAddItems == '1'",
+                "ui:disabled": true,
+                "ui:width": "33%"
+              },
+              "surplusCount": {
+                "title": "剩余库存",
+                "description": "",
+                "type": "string",
+                "maxLength": 16,
+                "minLength": 1,
+                "ui:disabled": true,
+                "ui:width": "50%"
+              },
+              "groupNoActiveAllCount": {
+                "title": "奖品组未生效总库存",
+                "description": "",
+                "type": "string",
+                "ui:hidden": "groupHasAddItems == '1'",
+                "ui:disabled": true,
+                "ui:width": "33%"
+              },
+              "userGroupWinningLimitTotal": {
+                "title": "该奖品组单用户可中次数",
+                "description": "",
+                "type": "string",
+                "maxLength": 16,
+                "minLength": 1,
+                "ui:hidden": "@['LOTTERY'].indexOf(formData.wfCommonInfo.productCode)===-1",
+                "ui:width": "50%"
+              },
+              "groupShowAdvancedSetting": {
+                "title": "库存高级配置展开显示（收起不影响功能）",
+                "description": "",
+                "type": "boolean"
+              },
+              "userGroupWinningLimitDay": {
+                "title": "该奖品组单用户每天可中次数",
+                "description": "",
+                "type": "string",
+                "maxLength": 16,
+                "minLength": 1,
+                "ui:hidden": "@['LOTTERY'].indexOf(formData.wfCommonInfo.productCode)===-1 || groupShowAdvancedSetting == false",
+                "ui:width": "50%"
+              },
+              "userGroupWinningLimitWeek": {
+                "title": "该奖品组单用户每周可中次数",
+                "description": "",
+                "type": "string",
+                "maxLength": 16,
+                "minLength": 1,
+                "ui:hidden": "@['LOTTERY'].indexOf(formData.wfCommonInfo.productCode)===-1 || groupShowAdvancedSetting == false",
+                "ui:width": "50%"
+              },
+              "lotteryApplyMsg": {
+                "title": "中奖提示文案",
+                "description": "",
+                "type": "string",
+                "ui:options": { "placeholder": "如：恭喜您抽中xx奖品" },
+                "ui:hidden": "@['LOTTERY'].indexOf(formData.wfCommonInfo.productCode)===-1"
+              },
+              "groupAddLimitText": {
+                "title": "定时添加库存",
+                "description": "",
+                "type": "string",
+                "ui:widget": "text",
+                "ui:hidden": "groupShowAdvancedSetting == false"
+              },
+              "groupHasAddItems": {
+                "title": "奖品组是否添加了添加库存的item",
+                "description": "",
+                "type": "string",
+                "default": "1",
+                "ui:hidden": true
+              },
+              "groupIncrInventoryItems": {
+                "minItems": 0,
+                "maxItems": 30,
+                "type": "array",
+                "items": {
+                  "properties": {
+                    "groupAddTime": {
+                      "title": "补充时间",
+                      "description": "",
+                      "type": "string",
+                      "ui:widget": "date",
+                      "ui:disabled": false,
+                      "ui:width": "40%"
+                    },
+                    "groupAddCount": {
+                      "title": "补充数量",
+                      "description": "",
+                      "type": "string",
+                      "pattern": "^([1-9]\\d*|0)$",
+                      "ui:disabled": false,
+                      "ui:width": "30%"
+                    },
+                    "groupValidCount": {
+                      "title": "已生效数量",
+                      "description": "",
+                      "type": "string",
+                      "pattern": "^([1-9]\\d*|0)$",
+                      "ui:disabled": true,
+                      "ui:width": "30%"
+                    },
+                    "groupTaskId": {
+                      "title": "执行添加库存任务的Id",
+                      "description": "",
+                      "type": "string",
+                      "ui:hidden": true
+                    },
+                    "groupItemId": {
+                      "title": "补充库存的记录Id",
+                      "description": "",
+                      "type": "string",
+                      "ui:hidden": true
+                    }
+                  },
+                  "type": "object",
+                  "required": ["groupAddTime", "groupAddCount"],
+                  "title": "设置定时补充库存",
+                  "name": "limitGroupAddItem"
+                },
+                "ui:options": { "foldable": true },
+                "ui:hidden": "groupShowAdvancedSetting == false"
+              },
+              "prizeConfig": {
+                "title": "奖品配置",
+                "description": "",
+                "type": "string",
+                "ui:widget": "text"
+              },
+              "prizeList": {
+                "minItems": 1,
+                "maxItems": 8,
+                "type": "array",
+                "items": {
+                  "properties": {
+                    "couponName": {
+                      "title": "奖品名称",
+                      "description": "",
+                      "type": "string",
+                      "maxLength": 11
+                    },
+                    "prizeType": {
+                      "title": "奖品类型",
+                      "description": "",
+                      "type": "string",
+                      "enum": [
+                        "FLIGGY_NEW_COUPON",
+                        "BENEFIT_CENTER",
+                        "FLIGGY_CARD_PACKAGE",
+                        "EMPTY_PRIZE",
+                        "FLIGGY_F2_VIP",
+                        "TAOBAO_COUPON",
+                        "VIRTUAL_BONUS_POINTS",
+                        "PUSH_MESSAGE",
+                        "ALITRIP_UMP_COMMON_COUPON",
+                        "ALITRIP_COUPON",
+                        "FLIGGY_MILEAGE",
+                        "ALIPAY_SHOP_BONUS",
+                        "ALIPAY_OVERSEA_COUPON",
+                        "FLIGGY_RIGHT",
+                        "ALIPAY318_FLIGGY_NEW_COUPON",
+                        "THURSDAY_DOUBLE_MILES",
+                        "WRITE_OFF_CERTIFICATE_COUPON",
+                        "CERTIFICATE_COUPON_PACKAGE",
+                        "FLIGGY_F1_VIP",
+                        "LATOUR2_BENEFIT",
+                        "ALIPAY_OFFLINE_VOUCHER",
+                        "ALIPAY_RED_PACKED",
+                        "DREAM_COUPON_VIRTUAL_BONUS_POINTS",
+                        "RANDOM_AMT_ALIPAY_RED_PACKED_4_DREAM_COUPON",
+                        "RANDOM_AMT_FLIGGY_RED_PACKED_4_DREAM_COUPON",
+                        "FLIGGY_TCCP_RIGHT",
+                        "CYCLE_FLIGGY_NEW_COUPON",
+                        "FLIGGY_VOUCHER",
+                        "SUPER_VIP_CUSTOM_FREE_TICKET",
+                        "SUPER_VIP_CUSTOM_FEIZHU",
+                        "SUPER_VIP_CUSTOM_TRAIN_NO_WORRIES_BACK",
+                        "SUPER_VIP_CUSTOM_MULTI_MILES",
+                        "REDEEM_CODE",
+                        "YOUKU_RECHARGE"
+                      ],
+                      "enumNames": [
+                        "飞猪新卡券(除随机面额优惠券)",
+                        "权益中心",
+                        "飞猪玩乐卡",
+                        "空奖品",
+                        "飞猪F3(原F2)会员",
+                        "淘宝UMP优惠券",
+                        "虚拟积分(抽奖凭证)",
+                        "push奖品",
+                        "航旅平台券",
+                        "航旅平台老券(含020券)",
+                        "飞猪里程",
+                        "支付宝到店红包",
+                        "支付宝境外线下券",
+                        "飞猪会员权益资源",
+                        "支付宝318专用飞猪新卡券",
+                        "周四会员福利日里程翻倍",
+                        "核销凭证券",
+                        "新玩法凭证类产品",
+                        "飞猪F1会员",
+                        "拉菲2权益",
+                        "支付宝线下券",
+                        "支付宝红包",
+                        "梦想券专用虚拟积分",
+                        "梦想券专用支付宝红包",
+                        "梦想券专用飞猪红包",
+                        "履约链路发放飞猪权益资源",
+                        "周期有效的飞猪新卡券",
+                        "飞猪资格凭证",
+                        "定制超级会员4张0.1元景区奖品",
+                        "定制超级会员菲住奖品",
+                        "定制超级会员12张火车票无忧退奖品",
+                        "定制超级会员里程翻倍奖品",
+                        "兑换码",
+                        "优酷直冲"
+                      ]
+                    },
+                    "fliggyNewCouponType": {
+                      "title": "卡券类型",
+                      "description": "",
+                      "type": "string",
+                      "enum": ["288", "283", "287", "285", "289"],
+                      "enumNames": [
+                        "平台出资优惠券（9）",
+                        "行业商家优惠券（4）",
+                        "日历房酒店纯平台出资优惠券（6）",
+                        "飞猪红包（10）",
+                        "资格券（0）"
+                      ],
+                      "ui:hidden": true
+                    },
+                    "rightsId": {
+                      "title": "模板Id",
+                      "type": "string",
+                      "ui:widget": "CouponInfoLoader",
+                      "ui:hidden": "prizeType=='YOUKU_RECHARGE' || prizeType=='FLIGGY_F2_VIP' || prizeType=='PUSH_MESSAGE' || prizeType=='FLIGGY_MILEAGE' || prizeType=='ALITRIP_EXPERIENCE' || prizeType == 'THURSDAY_DOUBLE_MILES' || prizeType=='COMPLETE_TASK_NODE' || prizeType=='SUPER_VIP_CUSTOM_MULTI_MILES'"
+                    },
+                    "channel": {
+                      "title": "渠道",
+                      "description": "",
+                      "type": "string",
+                      "ui:hidden": "prizeType!='ALITRIP_UMP_COMMON_COUPON' && prizeType!='THURSDAY_DOUBLE_MILES' && prizeType!='SUPER_VIP_CUSTOM_MULTI_MILES' && prizeType!='LATOUR2_BENEFIT' && prizeType!='ALITRIP_EXPERIENCE' && prizeType!='FLIGGY_TCCP_RIGHT' && prizeType!='FLIGGY_RIGHT'"
+                    },
+                    "source": {
+                      "title": "卡券发放sourceId",
+                      "description": "",
+                      "type": "string",
+                      "ui:widget": "asyncSelect2",
+                      "ui:hidden": "prizeType!='FLIGGY_NEW_COUPON' && prizeType!='ALIPAY318_FLIGGY_NEW_COUPON' && prizeType!='CYCLE_FLIGGY_NEW_COUPON'"
+                    },
+                    "pushBizCode": {
+                      "title": "bizCode",
+                      "description": "",
+                      "type": "string",
+                      "ui:hidden": "prizeType!='PUSH_MESSAGE'"
+                    },
+                    "actionCode": {
+                      "title": "actionCode",
+                      "description": "",
+                      "type": "string",
+                      "ui:hidden": "prizeType!='PUSH_MESSAGE'"
+                    },
+                    "pushExtInfo": {
+                      "title": "pushExtInfo",
+                      "description": "",
+                      "type": "string",
+                      "ui:hidden": "prizeType!='PUSH_MESSAGE'"
+                    },
+                    "virtualValue": {
+                      "title": "虚拟积分发放数量(1代表抽奖一次)",
+                      "description": "",
+                      "type": "number",
+                      "ui:hidden": "prizeType!='VIRTUAL_BONUS_POINTS'"
+                    },
+                    "durationDays": {
+                      "title": "会员期限",
+                      "description": "",
+                      "type": "string",
+                      "default": "365",
+                      "ui:hidden": "prizeType!='FLIGGY_F2_VIP' && prizeType!='FLIGGY_TCCP_RIGHT' && prizeType!='FLIGGY_RIGHT'"
+                    },
+                    "vipActiveChannel": {
+                      "title": "F1会员激活渠道",
+                      "description": "",
+                      "type": "string",
+                      "ui:hidden": "prizeType!='FLIGGY_F1_VIP'"
+                    },
+                    "youkuRechargeActivityToken": {
+                      "title": "优酷活动Token",
+                      "description": "",
+                      "type": "string",
+                      "ui:hidden": "prizeType!='YOUKU_RECHARGE'"
+                    },
+                    "businessLine": {
+                      "title": "业务线",
+                      "description": "",
+                      "type": "string",
+                      "enum": [
+                        "TRIP_PUBLIC",
+                        "TRIP_DOMESTIC_AIR",
+                        "TRIP_INTERNATIONAL_AIR",
+                        "TRIP_HOTEL",
+                        "TRIP_HOTEL_PKG",
+                        "TRIP_HOLIDAY",
+                        "TRIP_ENTRANCE",
+                        "TRIP_TRAIN",
+                        "TRIP_CAR_SERVICE",
+                        "TRIP_BUS",
+                        "TRIP_MEMBERSHIP",
+                        "TRIP_MEETING_PLACE"
+                      ],
+                      "enumNames": [
+                        "公共",
+                        "国内机票",
+                        "国际机票",
+                        "酒店日历房",
+                        "酒店套餐",
+                        "度假",
+                        "门票",
+                        "火车票",
+                        "用车",
+                        "汽车票",
+                        "会员",
+                        "主会场"
+                      ],
+                      "ui:hidden": "prizeType!='FLIGGY_NEW_COUPON' && prizeType!='ALIPAY318_FLIGGY_NEW_COUPON' && prizeType!='CYCLE_FLIGGY_NEW_COUPON'"
+                    },
+                    "couponDesc": {
+                      "title": "奖品描述",
+                      "description": "",
+                      "type": "string",
+                      "maxLength": 11,
+                      "ui:hidden": "prizeType=='PUSH_MESSAGE' || prizeType=='WRITE_OFF_CERTIFICATE_COUPON' || prizeType=='CERTIFICATE_COUPON_PACKAGE' || prizeType =='THURSDAY_DOUBLE_MILES'|| prizeType =='SUPER_VIP_CUSTOM_MULTI_MILES' || prizeType=='COMPLETE_TASK_NODE'"
+                    },
+                    "couponDescPic": {
+                      "title": "奖品logo",
+                      "description": "",
+                      "type": "string",
+                      "ui:hidden": "prizeType=='FLIGGY_CARD_PACKAGE'||prizeType=='PUSH_MESSAGE' || prizeType=='WRITE_OFF_CERTIFICATE_COUPON' || prizeType=='CERTIFICATE_COUPON_PACKAGE' || prizeType =='THURSDAY_DOUBLE_MILES'|| prizeType =='SUPER_VIP_CUSTOM_MULTI_MILES' || prizeType=='COMPLETE_TASK_NODE'"
+                    },
+                    "couponUseUrl": {
+                      "title": "奖品去使用链接(无线)",
+                      "description": "",
+                      "type": "string",
+                      "ui:hidden": "prizeType=='PUSH_MESSAGE'|| prizeType=='WRITE_OFF_CERTIFICATE_COUPON' || prizeType=='CERTIFICATE_COUPON_PACKAGE' || prizeType =='THURSDAY_DOUBLE_MILES'|| prizeType =='SUPER_VIP_CUSTOM_MULTI_MILES' || prizeType=='COMPLETE_TASK_NODE'"
+                    },
+                    "hidden": {
+                      "title": "卡券不在手淘、飞猪卡券包露出（支付宝是否露出在优惠配置时决定）",
+                      "description": "",
+                      "type": "boolean",
+                      "ui:hidden": "prizeType!='FLIGGY_NEW_COUPON'"
+                    },
+                    "resourceId": {
+                      "title": "奖品资源Id",
+                      "description": "",
+                      "type": "string",
+                      "ui:hidden": true
+                    },
+                    "rightsSellerType": {
+                      "title": "权益中心类型",
+                      "description": "",
+                      "type": "string",
+                      "enum": ["135", "137", "138", "139", "141", "142", "145"],
+                      "enumNames": [
+                        "大麦",
+                        "虾米",
+                        "银泰券",
+                        "口碑",
+                        "饿了么",
+                        "淘票票",
+                        "优酷"
+                      ],
+                      "ui:hidden": "prizeType!='BENEFIT_CENTER'"
+                    },
+                    "exchangeTotal": {
+                      "title": "兑换次数上限",
+                      "description": "",
+                      "type": "number",
+                      "min": 1,
+                      "ui:hidden": "prizeType!='FLIGGY_RIGHT'"
+                    },
+                    "taobaoCouponInstanceSource": {
+                      "title": "卡券传播渠道",
+                      "description": "",
+                      "type": "number",
+                      "ui:hidden": "prizeType!='TAOBAO_COUPON'"
+                    },
+                    "taobaoCouponQuerySource": {
+                      "title": "卡券领取来源",
+                      "description": "",
+                      "type": "number",
+                      "ui:hidden": "prizeType!='TAOBAO_COUPON'"
+                    },
+                    "taobaoCouponSpreadId": {
+                      "title": "红包/卡券 Spread Id",
+                      "description": "",
+                      "type": "number",
+                      "ui:hidden": "prizeType!='TAOBAO_COUPON'"
+                    },
+                    "taobaoCouponSupplierId": {
+                      "title": "卖家uid",
+                      "description": "",
+                      "type": "number",
+                      "ui:hidden": "prizeType!='TAOBAO_COUPON'"
+                    },
+                    "taobaoCouponUUID": {
+                      "title": "红包/卡券 uuid",
+                      "description": "",
+                      "type": "string",
+                      "ui:hidden": "prizeType!='TAOBAO_COUPON'"
+                    },
+                    "syncAlipayCoupon": {
+                      "title": "店铺券/商品券同步到支付宝卡包（仅支付宝发放渠道可选）",
+                      "description": "",
+                      "type": "boolean",
+                      "ui:hidden": "@['EXCHANGE','AWARD', 'LOTTERY'].indexOf(formData.wfCommonInfo.productCode)===-1||prizeType!='TAOBAO_COUPON'"
+                    },
+                    "fliggyNewCouponCycleType": {
+                      "title": "卡券有效期模式",
+                      "description": "",
+                      "type": "string",
+                      "enum": ["1", "2", "3"],
+                      "enumNames": ["自然周", "自然月", "自然年"],
+                      "ui:hidden": "prizeType!='CYCLE_FLIGGY_NEW_COUPON' && prizeType!='FLIGGY_VOUCHER'"
+                    },
+                    "mileageCount": {
+                      "title": "发放里程数",
+                      "description": "",
+                      "type": "string",
+                      "pattern": "^([1-9]\\d*|0)$",
+                      "ui:hidden": "prizeType!='FLIGGY_MILEAGE'"
+                    },
+                    "mileageMemo": {
+                      "title": "发放原因文案",
+                      "description": "",
+                      "type": "string",
+                      "ui:hidden": "prizeType!='FLIGGY_MILEAGE'"
+                    },
+                    "showAdvancedSetting": {
+                      "title": "高级配置",
+                      "description": "",
+                      "type": "boolean"
+                    },
+                    "faceValue": {
+                      "title": "面额",
+                      "description": "",
+                      "type": "string",
+                      "enum": ["1", "2", "3", "4", "5"],
+                      "enumNames": [
+                        "固定金额",
+                        "固定折扣",
+                        "减至",
+                        "纯文案",
+                        "自定义前中后缀"
+                      ],
+                      "ui:hidden": "showAdvancedSetting==false || prizeType=='FLIGGY_F2_VIP'||prizeType=='VIRTUAL_BONUS_POINTS'"
+                    },
+                    "fixedAmountBefore": {
+                      "title": "",
+                      "description": "",
+                      "type": "string",
+                      "ui:options": { "addonBefore": "满", "addonAfter": "元" },
+                      "ui:hidden": "showAdvancedSetting==false ||faceValue!='1'||prizeType=='FLIGGY_F2_VIP'||prizeType=='VIRTUAL_BONUS_POINTS'",
+                      "ui:width": "50%"
+                    },
+                    "fixedAmountAfter": {
+                      "title": "",
+                      "description": "",
+                      "type": "string",
+                      "ui:options": { "addonBefore": "减", "addonAfter": "元" },
+                      "ui:hidden": "showAdvancedSetting==false ||faceValue!='1'||prizeType=='FLIGGY_F2_VIP'||prizeType=='VIRTUAL_BONUS_POINTS'",
+                      "ui:width": "50%"
+                    },
+                    "discount": {
+                      "title": "",
+                      "description": "",
+                      "type": "string",
+                      "ui:options": { "addonAfter": "折" },
+                      "ui:hidden": "showAdvancedSetting==false ||faceValue!='2'||prizeType=='FLIGGY_F2_VIP'||prizeType=='VIRTUAL_BONUS_POINTS'",
+                      "ui:width": "50%"
+                    },
+                    "reduce": {
+                      "title": "",
+                      "description": "",
+                      "type": "string",
+                      "ui:options": { "addonAfter": "元" },
+                      "ui:hidden": "showAdvancedSetting==false ||faceValue!='3'||prizeType=='FLIGGY_F2_VIP'||prizeType=='VIRTUAL_BONUS_POINTS'",
+                      "ui:width": "50%"
+                    },
+                    "faceValuePurePrefixText": {
+                      "title": "前缀",
+                      "description": "",
+                      "type": "string",
+                      "ui:hidden": "showAdvancedSetting==false || faceValue!='5'",
+                      "ui:width": "50%"
+                    },
+                    "faceValuePureInfixText": {
+                      "title": "中缀",
+                      "description": "",
+                      "type": "string",
+                      "ui:hidden": "showAdvancedSetting==false || faceValue!='5'",
+                      "ui:width": "50%"
+                    },
+                    "faceValuePureText": {
+                      "title": "{{rootValue.faceValue=='5'?'后缀':''}}",
+                      "description": "",
+                      "type": "string",
+                      "ui:hidden": "{{ !(rootValue.showAdvancedSetting==false && rootValue.faceValue=='4' ) || !( rootValue.showAdvancedSetting==false && rootValue.faceValue=='5' ) }}"
+                    },
+                    "effectiveTimeType": {
+                      "title": "使用有效期",
+                      "description": "",
+                      "type": "string",
+                      "enum": ["1", "2", "3", "4"],
+                      "enumNames": [
+                        "固定时间",
+                        "自领取之时起",
+                        "自领取之日起",
+                        "纯文案"
+                      ],
+                      "ui:hidden": "showAdvancedSetting==false ||prizeType=='FLIGGY_F2_VIP'||prizeType=='VIRTUAL_BONUS_POINTS'"
+                    },
+                    "beginTime": {
+                      "title": "开始时间",
+                      "description": "",
+                      "type": "string",
+                      "ui:widget": "date",
+                      "ui:hidden": "showAdvancedSetting==false ||effectiveTimeType!='1'||prizeType=='FLIGGY_F2_VIP'||prizeType=='VIRTUAL_BONUS_POINTS'",
+                      "ui:width": "50%"
+                    },
+                    "endTime": {
+                      "title": "结束时间",
+                      "description": "",
+                      "type": "string",
+                      "ui:widget": "date",
+                      "ui:hidden": "showAdvancedSetting==false ||effectiveTimeType!='1'||prizeType=='FLIGGY_F2_VIP'||prizeType=='VIRTUAL_BONUS_POINTS'",
+                      "ui:width": "50%"
+                    },
+                    "effectiveMin": {
+                      "title": "",
+                      "description": "",
+                      "type": "string",
+                      "pattern": "^[0-9]+$",
+                      "ui:options": { "addonAfter": "分钟" },
+                      "ui:hidden": "showAdvancedSetting==false ||effectiveTimeType!='2'",
+                      "ui:width": "50%"
+                    },
+                    "effectiveDay": {
+                      "title": "",
+                      "description": "",
+                      "type": "string",
+                      "pattern": "^[0-9]+$",
+                      "ui:options": { "addonAfter": "天" },
+                      "ui:hidden": "showAdvancedSetting==false ||effectiveTimeType!='3'",
+                      "ui:width": "50%"
+                    },
+                    "effectTimePureText": {
+                      "title": "",
+                      "description": "",
+                      "type": "string",
+                      "ui:hidden": "showAdvancedSetting==false ||effectiveTimeType!='4'"
+                    },
+                    "toUseUrl4Pc": {
+                      "title": "奖品去使用链接(PC)",
+                      "description": "",
+                      "type": "string",
+                      "ui:hidden": "showAdvancedSetting==false ||prizeType=='FLIGGY_F2_VIP'||prizeType=='VIRTUAL_BONUS_POINTS'|| prizeType=='WRITE_OFF_CERTIFICATE_COUPON'"
+                    },
+                    "toUseUrl4Wx": {
+                      "title": "奖品去使用链接(WX)",
+                      "description": "",
+                      "type": "string",
+                      "ui:hidden": "showAdvancedSetting==false ||prizeType=='FLIGGY_F2_VIP'||prizeType=='VIRTUAL_BONUS_POINTS'|| prizeType=='WRITE_OFF_CERTIFICATE_COUPON'"
+                    },
+                    "tag": {
+                      "title": "tag",
+                      "description": "",
+                      "type": "string",
+                      "ui:hidden": "prizeType!='ALITRIP_TAG'"
+                    },
+                    "count": {
+                      "title": "数量",
+                      "description": "",
+                      "type": "string",
+                      "ui:hidden": "prizeType!='MOVIE_COUPON' || prizeType!='FLIGGY_VOUCHER'"
+                    },
+                    "desc": {
+                      "title": "说明",
+                      "description": "",
+                      "type": "string",
+                      "ui:hidden": "prizeType!='MOVIE_COUPON' || prizeType!='ALIPAY_RED_PACKED' || prizeType!='ALIPAY_OFFLINE_VOUCHER'"
+                    },
+                    "url": {
+                      "title": "URL",
+                      "description": "",
+                      "type": "string",
+                      "ui:hidden": "prizeType!='MOVIE_COUPON'"
+                    },
+                    "partnerCode": {
+                      "title": "partnerCode",
+                      "description": "",
+                      "type": "string",
+                      "ui:hidden": "prizeType!='MOVIE_COUPON'"
+                    },
+                    "amount": {
+                      "title": "数值",
+                      "description": "支付宝红包的单位为分，填100等于1元",
+                      "type": "string",
+                      "ui:hidden": "prizeType!='MOVIE_COUPON' && prizeType!='ALIPAY_RED_PACKED' && prizeType!='ALITRIP_EXPERIENCE' && prizeType!='FUND_PLATFORM_SEND' && prizeType!='ALITRIP_COUPON'"
+                    },
+                    "cashPoolId": {
+                      "title": "资金池ID",
+                      "description": "",
+                      "type": "string",
+                      "ui:hidden": "prizeType!='FUND_PLATFORM_SEND'"
+                    },
+                    "cashPoolUserId": {
+                      "title": "资金池所属用户ID",
+                      "description": "",
+                      "type": "string",
+                      "ui:hidden": "prizeType!='FUND_PLATFORM_SEND'"
+                    },
+                    "subBusinessType": {
+                      "title": "子业务类型",
+                      "description": "",
+                      "type": "string",
+                      "ui:hidden": "prizeType!='FUND_PLATFORM_SEND'"
+                    },
+                    "priceReduce": {
+                      "title": "价值(面额)(元):扣减资源数",
+                      "description": "",
+                      "type": "string",
+                      "ui:hidden": "prizeType!='FUND_PLATFORM_SEND'"
+                    },
+                    "securityCode": {
+                      "title": "安全码",
+                      "description": "",
+                      "type": "string",
+                      "ui:hidden": "prizeType!='FUND_PLATFORM_SEND'"
+                    },
+                    "topPrice": {
+                      "title": "最高价值(面额)(元)",
+                      "description": "",
+                      "type": "string",
+                      "ui:hidden": "prizeType!='FUND_PLATFORM_SEND'"
+                    },
+                    "stgCode": {
+                      "title": "投放Id",
+                      "description": "",
+                      "type": "string",
+                      "ui:hidden": "prizeType!='LATOUR2_BENEFIT'"
+                    },
+                    "multiple": {
+                      "title": "里程翻倍倍数",
+                      "description": "",
+                      "type": "string",
+                      "ui:hidden": "prizeType!='THURSDAY_DOUBLE_MILES' && prizeType!='SUPER_VIP_CUSTOM_MULTI_MILES'"
+                    },
+                    "maxSendMiles": {
+                      "title": "最大里程发放数量",
+                      "description": "",
+                      "type": "string",
+                      "ui:hidden": "prizeType!='THURSDAY_DOUBLE_MILES' && prizeType!='SUPER_VIP_CUSTOM_MULTI_MILES'"
+                    },
+                    "subActMaxSendMiles": {
+                      "title": "该活动最大里程发放数量",
+                      "description": "",
+                      "type": "string",
+                      "ui:hidden": "prizeType!='THURSDAY_DOUBLE_MILES' && prizeType!='SUPER_VIP_CUSTOM_MULTI_MILES'"
+                    },
+                    "dreamCouponMaxAmount": {
+                      "title": "最大优惠红包金额",
+                      "description": "",
+                      "type": "number",
+                      "ui:hidden": "prizeType!='DREAM_COUPON_VIRTUAL_BONUS_POINTS' "
+                    },
+                    "dreamCouponPrizeType": {
+                      "title": "对应发放的红包类型",
+                      "description": "",
+                      "type": "string",
+                      "enum": ["1", "2"],
+                      "enumNames": ["支付宝红包", "飞猪红包"],
+                      "ui:hidden": "prizeType!='DREAM_COUPON_VIRTUAL_BONUS_POINTS'"
+                    },
+                    "dreamCouponMatchVirtualScoreActivityId": {
+                      "title": "对应匹配的虚拟积分活动id",
+                      "description": "",
+                      "type": "number",
+                      "ui:hidden": "prizeType!='RANDOM_AMT_ALIPAY_RED_PACKED_4_DREAM_COUPON' && prizeType!='RANDOM_AMT_FLIGGY_RED_PACKED_4_DREAM_COUPON'"
+                    }
+                  },
+                  "type": "object",
+                  "required": [
+                    "couponName",
+                    "prizeType",
+                    "fliggyNewCouponType",
+                    "rightsId",
+                    "channel",
+                    "source",
+                    "pushBizCode",
+                    "actionCode",
+                    "pushExtInfo",
+                    "youkuRechargeActivityToken",
+                    "rightsSellerType",
+                    "taobaoCouponInstanceSource",
+                    "taobaoCouponQuerySource",
+                    "taobaoCouponSpreadId",
+                    "taobaoCouponSupplierId",
+                    "taobaoCouponUUID",
+                    "fliggyNewCouponCycleType",
+                    "mileageCount",
+                    "effectiveMin",
+                    "effectiveDay",
+                    "tag",
+                    "count",
+                    "desc",
+                    "url",
+                    "partnerCode",
+                    "amount",
+                    "cashPoolId",
+                    "cashPoolUserId",
+                    "subBusinessType",
+                    "priceReduce",
+                    "securityCode",
+                    "topPrice",
+                    "stgCode",
+                    "dreamCouponMaxAmount",
+                    "dreamCouponPrizeType",
+                    "dreamCouponMatchVirtualScoreActivityId"
+                  ],
+                  "title": "卡券配置",
+                  "name": "prizeTotalConfig"
+                },
+                "ui:options": { "foldable": true }
+              }
+            },
+            "type": "object",
+            "required": [
+              "name",
+              "lotteryProbability",
+              "groupId",
+              "inventoryId",
+              "inventoryLimit"
+            ],
+            "name": "prizeGroupConfig"
+          },
+          "ui:options": { "foldable": true }
+        }
+      },
+      "type": "object",
+      "required": [],
+      "title": "奖品组配置列表",
+      "name": "prizeGroupConfigList"
+    },
+    "prizeSendRuleList": {
+      "properties": {
+        "prizeSendRuleList": {
+          "minItems": 0,
+          "maxItems": 8,
+          "type": "array",
+          "items": {
+            "properties": {
+              "ruleDesc": {
+                "title": "规则描述",
+                "description": "",
+                "type": "string",
+                "maxLength": 12,
+                "minLength": 1,
+                "ui:width": "50%"
+              },
+              "unMatchNotice": {
+                "title": "未命中提示",
+                "description": "",
+                "type": "string",
+                "maxLength": 36,
+                "minLength": 1,
+                "ui:width": "50%"
+              },
+              "strategyId": {
+                "title": "规则策略Id",
+                "description": "",
+                "type": "string",
+                "ui:hidden": true
+              },
+              "ruleConditionCfg": {
+                "minItems": 1,
+                "maxItems": 8,
+                "type": "array",
+                "items": {
+                  "properties": {
+                    "conditionName": {
+                      "title": "",
+                      "description": "",
+                      "type": "string",
+                      "enum": [
+                        "3002",
+                        "3004",
+                        "3008",
+                        "4001",
+                        "5001",
+                        "9001",
+                        "10001",
+                        "20002",
+                        "24001",
+                        "24004",
+                        "26001",
+                        "27001",
+                        "27002",
+                        "35001",
+                        "35002",
+                        "36001",
+                        "59001",
+                        "59002",
+                        "60001",
+                        "97001",
+                        "115001",
+                        "116001",
+                        "117001",
+                        "131001",
+                        "134001",
+                        "169001",
+                        "170002",
+                        "173001",
+                        "178001",
+                        "180001",
+                        "181001",
+                        "182001",
+                        "182002",
+                        "183001",
+                        "184001",
+                        "185001",
+                        "186001",
+                        "187001",
+                        "188001",
+                        "189001",
+                        "194001",
+                        "200001",
+                        "201001",
+                        "207001",
+                        "208001",
+                        "212001",
+                        "213001",
+                        "215001",
+                        "216001",
+                        "219001",
+                        "220001",
+                        "221001",
+                        "222001",
+                        "223001",
+                        "224001",
+                        "225001",
+                        "226001",
+                        "229001",
+                        "230002",
+                        "231001",
+                        "232001",
+                        "234001",
+                        "234002",
+                        "235001",
+                        "235002",
+                        "236001",
+                        "237001",
+                        "238001",
+                        "239001",
+                        "240001",
+                        "241001",
+                        "244001",
+                        "245001",
+                        "250001",
+                        "251001",
+                        "251002",
+                        "252001",
+                        "253001",
+                        "255001",
+                        "257001",
+                        "258001",
+                        "259001",
+                        "261001",
+                        "271001",
+                        "273001",
+                        "281001",
+                        "285001",
+                        "286001",
+                        "289001",
+                        "291001"
+                      ],
+                      "enumNames": [
+                        "用户是否拥有足够里程值",
+                        "是否有真实姓名",
+                        "用户拥有此航旅标签",
+                        "是否为实名认证用户",
+                        "是否拥有用户勋章",
+                        "是否拥有航旅可用卡券",
+                        "是否是航旅APP新用户",
+                        "判断是否是指定LBS位移id",
+                        "动态传参(判断用户是否有可用卡券)",
+                        "LBS位移",
+                        "用户是否领取过某卡券",
+                        "主站订单商品单价(单位为分)",
+                        "主站订单消息类型",
+                        "是否天猫超级会员",
+                        "是否天猫APASS会员",
+                        "用户是否在白名单中",
+                        "是否拥有有效淘宝卡券(作废)",
+                        "是否领取过淘宝卡券",
+                        "是否属于人群",
+                        "用户满送活动累计金额",
+                        "交易订单是否包含本人",
+                        "是否参与过问卷调查",
+                        "是否属于春运5折类目黑名单",
+                        "用户是否完成某个节点",
+                        "是否使用过淘宝卡券",
+                        "是否参与过问卷调查新版",
+                        "支付订单含尾款支付",
+                        "淘金币用户判断",
+                        "是否预售订单",
+                        "酒店checkOut时间",
+                        "在酒店hid名单",
+                        "在酒店卖家id名单",
+                        "checkIn时间在此之后",
+                        "checkOut时间在此之前",
+                        "checkIn时间在此之前",
+                        "订单创建在此之前",
+                        "订单创建在此之后",
+                        "是否酒店checkIn事件",
+                        "是否信用住结账成功事件",
+                        "是否酒店checkout事件",
+                        "是否码上游支付",
+                        "尾款支付在此之前",
+                        "尾款支付在此之后",
+                        "是否在booking特定hid名单A",
+                        "是否在booking特定hid名单B",
+                        "用户虚拟积分",
+                        "伙伴会员注册状态",
+                        "里程翻倍订单在此之前",
+                        "里程翻倍订单在此之后",
+                        "里程翻倍订单来源是否飞猪APP",
+                        "用户是否有足够积分",
+                        "用户互动虚拟积分",
+                        "流水号查询用户互动虚拟积分",
+                        "是否领取过指定活动中指定奖品组的奖品",
+                        "用户互动虚拟积分不累计本次",
+                        "是否领取过飞猪卡(T领取过F未领取)",
+                        "永真规则",
+                        "是否领取过淘宝Ump优惠券(new)",
+                        "用户是否在白名单中(new)",
+                        "用户是否有有效飞猪新卡卷(new)",
+                        "用户是否参加过新玩法活动",
+                        "判断星巴克活动人群",
+                        "星巴克注册后发奖人群判断",
+                        "是否在booking特定hid名单C",
+                        "是否在booking特定hid名单I",
+                        "是否在booking特定hid名单D",
+                        "是否在booking特定hid名单E",
+                        "是否在booking特定hid名单F",
+                        "是否在booking特定hid名单G",
+                        "是否在booking特定hid名单H",
+                        "支付时是否持有有效的凭证券",
+                        "用户是否领取过飞猪新卡卷-new",
+                        "商品id白名单",
+                        "批量查询用户是否拥有飞猪新卡券",
+                        "订单号白名单",
+                        "99梦想券抽奖资格判断",
+                        "商品itemTag白名单",
+                        "是否酒店日历房面付订单",
+                        "是否是火车票抢票订单",
+                        "订单商家实收款判断",
+                        "用户有效的trippe积分判断",
+                        "是否是预售订单",
+                        "身份证在模版下未领取或已过期",
+                        "订单支付状态判断",
+                        "是否是飞猪app新下载用户",
+                        "用户是否有有效飞猪日常卡",
+                        "是否属于人群(new)",
+                        "是否属于人群(不要用)",
+                        "飞猪会员等级-升级",
+                        "批量查看用户是否有(可用、冻结、核销、删除)的优惠券"
+                      ],
+                      "ui:options": { "showSearch": true },
+                      "ui:width": "45%"
+                    },
+                    "3002_comparator": {
+                      "enumNames": [
+                        "等于(数值)",
+                        "大于（数值）",
+                        "大于等于(数值)",
+                        "小于(数值)",
+                        "小于等于(数值)"
+                      ],
+                      "enum": ["1", "9", "10", "12", "14"],
+                      "ui:hidden": "conditionName!=3002",
+                      "ui:width": "15%"
+                    },
+                    "3002_return_value": {
+                      "type": "string",
+                      "ui:hidden": "conditionName!=3002",
+                      "ui:width": "40%"
+                    },
+                    "3004_comparator": {
+                      "enumNames": ["等于(布尔)"],
+                      "enum": ["6"],
+                      "ui:hidden": "conditionName!=3004",
+                      "ui:width": "15%"
+                    },
+                    "3004_return_value": {
+                      "type": "string",
+                      "ui:hidden": "conditionName!=3004",
+                      "ui:width": "40%"
+                    },
+                    "3008_comparator": {
+                      "enumNames": ["等于(布尔)"],
+                      "enum": ["6"],
+                      "ui:hidden": "conditionName!=3008",
+                      "ui:width": "15%"
+                    },
+                    "3008_return_value": {
+                      "enumNames": ["是", "否"],
+                      "enum": ["true", "false"],
+                      "ui:hidden": "conditionName!=3008",
+                      "ui:width": "40%"
+                    },
+                    "3008_params_tag": {
+                      "type": "string",
+                      "title": "航旅标签",
+                      "ui:hidden": "conditionName!=3008",
+                      "ui:width": "40%"
+                    },
+                    "4001_comparator": {
+                      "enumNames": ["等于(布尔)"],
+                      "enum": ["6"],
+                      "ui:hidden": "conditionName!=4001",
+                      "ui:width": "15%"
+                    },
+                    "4001_return_value": {
+                      "enumNames": ["是", "否"],
+                      "enum": ["true", "false"],
+                      "ui:hidden": "conditionName!=4001",
+                      "ui:width": "40%"
+                    },
+                    "5001_comparator": {
+                      "enumNames": [
+                        "不相交(左右均集合)",
+                        "包含(左集合包含右集合)"
+                      ],
+                      "enum": ["17", "3001"],
+                      "ui:hidden": "conditionName!=5001",
+                      "ui:width": "15%"
+                    },
+                    "5001_return_value": {
+                      "enumNames": [
+                        "哇哦饭Lv3",
+                        "哇哦饭Lv4",
+                        "哇哦饭Lv1",
+                        "哇哦饭Lv2",
+                        "活动积极分子Lv2",
+                        "功盖神州",
+                        "点评达人Lv2",
+                        "点评达人Lv1",
+                        "欧莱雅会员勋章",
+                        "点评达人Lv3",
+                        "海信电视会员勋章",
+                        "维康会员勋章",
+                        "yearonyear会员勋章",
+                        "淘宝天下V5",
+                        "华为会员勋章",
+                        "哇哦饭Lv5",
+                        "海尔会员勋章",
+                        "哇哦饭Lv6",
+                        "雅安加油",
+                        "361°会员勋章",
+                        "爱国者会员勋章",
+                        "TCL会员勋章",
+                        "海鸥会员勋章",
+                        "神豆会员勋章",
+                        "品牌会员勋章",
+                        "资深买家Lv1",
+                        "资深买家Lv2",
+                        "乐扣乐扣会员勋章",
+                        "合买达人",
+                        "好奇会员勋章",
+                        "ThinkPad会员勋章",
+                        "长生鸟会员勋章",
+                        "奥运英雄",
+                        "多美滋会员勋章",
+                        "美的会员勋章",
+                        "中兴会员勋章",
+                        "亚都会员勋章",
+                        "一朵会员勋章",
+                        "小有所成",
+                        "实名认证",
+                        "图享家Lv2",
+                        "图享家Lv3",
+                        "图享家Lv1",
+                        "技嘉会员勋章",
+                        "波斯顿会员勋章",
+                        "圣元会员勋章",
+                        "圣荷会员勋章",
+                        "御泥坊会员勋章",
+                        "活动积极分子Lv3",
+                        "ABC会员勋章",
+                        "公益使者",
+                        "南极人会员勋章",
+                        "诺基亚会员勋章",
+                        "图享家Lv4",
+                        "淘宝十周年",
+                        "丽贝乐会员勋章",
+                        "图享家Lv5",
+                        "专辑潮人Lv1",
+                        "丝蓓绮会员勋章",
+                        "Bear小熊会员勋章",
+                        "台电会员勋章",
+                        "雀氏会员勋章",
+                        "smart合伙人勋章",
+                        "包邮卡",
+                        "社交DJ  LV3",
+                        "社交DJ  LV2",
+                        "超级队长",
+                        "怡丽会员勋章",
+                        "御泥坊会员勋章",
+                        "专辑潮人Lv3",
+                        "迈途会员勋章",
+                        "专辑潮人Lv2",
+                        "社交DJ  LV1",
+                        "创维会员勋章",
+                        "奔腾电工会员勋章",
+                        "联想手机会员勋章",
+                        "特邀评论员Lv3",
+                        "特邀评论员Lv4",
+                        "买一善一",
+                        "明一会员勋章",
+                        "高丝会员勋章",
+                        "特邀评论员Lv1",
+                        "特邀评论员Lv2",
+                        "好友爱",
+                        "分享控Lv5",
+                        "分享控Lv3",
+                        "分享控Lv4",
+                        "分享控Lv1",
+                        "分享控Lv2",
+                        "英伟达会员勋章",
+                        "水星家纺会员勋章",
+                        "游戏认证",
+                        "施华蔻会员勋章",
+                        "联想会员勋章",
+                        "奥朵会员勋章",
+                        "戴尔会员勋章",
+                        "认证车主",
+                        "笛莎会员勋章",
+                        "笛莎会员勋章",
+                        "金账户",
+                        "帅康会员勋章",
+                        "奔腾电器会员勋章",
+                        "活动积极分子Lv1",
+                        "昂达会员勋章",
+                        "网购达人Lv1",
+                        "网购达人Lv2",
+                        "网购达人Lv3",
+                        "亲情宝宝会员勋章",
+                        "超级买家Lv1",
+                        "超级买家Lv2",
+                        "铁血君品行会员勋章",
+                        "苏泊尔会员勋章",
+                        "醉美四川",
+                        "李宁会员勋章",
+                        "飞利浦会员勋章",
+                        "Hauswirt会员勋章",
+                        "恋上party LV2",
+                        "帮宝适会员勋章",
+                        "恋上party LV1",
+                        "试用先锋",
+                        "马拉丁会员勋章",
+                        "迪士尼会员勋章",
+                        "凡茜会员勋章",
+                        "领袖范Lv4",
+                        "哇哦金卡",
+                        "领袖范Lv5",
+                        "领袖范Lv2",
+                        "领袖范Lv3",
+                        "领袖范Lv1",
+                        "全球购会员",
+                        "蜜丝佛陀会员勋章",
+                        "相宜本草会员勋章",
+                        "英特尔会员勋章",
+                        "骆驼会员勋章",
+                        "淘宝天下V6",
+                        "美即会员勋章",
+                        "亦美珊会员勋章",
+                        "邦怡会员勋章",
+                        "探路者会员勋章",
+                        "雀巢会员勋章",
+                        "宝家丽会员勋章",
+                        "神舟会员勋章",
+                        "珀莱雅会员勋章",
+                        "电子券先锋",
+                        "联合利华会员勋章",
+                        "科沃斯会员勋章",
+                        "母婴达人Lv1",
+                        "富安娜会员勋章",
+                        "华硕会员勋章",
+                        "小狗会员勋章",
+                        "母婴达人Lv3",
+                        "惠氏会员勋章",
+                        "母婴达人Lv2",
+                        "宝洁会员勋章",
+                        "判案先锋",
+                        "判案达人",
+                        "北极绒会员勋章",
+                        "判案新秀",
+                        "淘宝新人",
+                        "淘宝信使"
+                      ],
+                      "enum": [
+                        "110303",
+                        "110304",
+                        "110301",
+                        "110302",
+                        "200901",
+                        "102001",
+                        "200502",
+                        "200501",
+                        "209201",
+                        "200503",
+                        "207301",
+                        "202801",
+                        "209601",
+                        "200101",
+                        "204701",
+                        "110305",
+                        "207701",
+                        "110306",
+                        "202401",
+                        "205401",
+                        "208901",
+                        "203101",
+                        "205001",
+                        "210301",
+                        "210701",
+                        "101701",
+                        "101702",
+                        "208001",
+                        "201601",
+                        "206101",
+                        "208401",
+                        "203901",
+                        "201201",
+                        "205801",
+                        "206501",
+                        "208801",
+                        "203501",
+                        "204201",
+                        "100101",
+                        "100501",
+                        "110402",
+                        "110403",
+                        "110401",
+                        "209101",
+                        "209103",
+                        "209102",
+                        "209501",
+                        "207201",
+                        "200801",
+                        "202701",
+                        "200401",
+                        "209901",
+                        "207601",
+                        "110404",
+                        "202301",
+                        "204601",
+                        "110405",
+                        "201101",
+                        "206901",
+                        "203001",
+                        "205301",
+                        "210201",
+                        "210601",
+                        "300101",
+                        "201503",
+                        "201502",
+                        "201901",
+                        "208301",
+                        "203801",
+                        "201103",
+                        "206401",
+                        "201102",
+                        "201501",
+                        "205701",
+                        "203401",
+                        "208701",
+                        "100603",
+                        "100604",
+                        "202201",
+                        "204101",
+                        "206001",
+                        "100601",
+                        "100602",
+                        "110501",
+                        "110105",
+                        "110103",
+                        "110104",
+                        "110101",
+                        "110102",
+                        "209001",
+                        "207101",
+                        "200701",
+                        "209401",
+                        "204901",
+                        "207501",
+                        "202601",
+                        "200301",
+                        "209801",
+                        "204501",
+                        "101901",
+                        "206801",
+                        "203301",
+                        "201001",
+                        "205201",
+                        "101101",
+                        "101102",
+                        "101103",
+                        "210101",
+                        "101501",
+                        "101502",
+                        "210501",
+                        "208201",
+                        "201801",
+                        "206301",
+                        "208601",
+                        "203701",
+                        "201402",
+                        "205601",
+                        "201401",
+                        "202101",
+                        "204401",
+                        "207901",
+                        "204001",
+                        "110204",
+                        "110601",
+                        "110205",
+                        "110202",
+                        "110203",
+                        "110201",
+                        "200601",
+                        "209301",
+                        "207001",
+                        "202901",
+                        "207401",
+                        "200201",
+                        "202501",
+                        "204801",
+                        "209701",
+                        "205501",
+                        "206701",
+                        "203201",
+                        "205101",
+                        "210401",
+                        "201701",
+                        "208101",
+                        "206201",
+                        "201301",
+                        "205901",
+                        "208501",
+                        "203601",
+                        "201303",
+                        "206601",
+                        "201302",
+                        "207801",
+                        "202002",
+                        "202003",
+                        "204301",
+                        "202001",
+                        "100001",
+                        "100401"
+                      ],
+                      "ui:hidden": "conditionName!=5001",
+                      "ui:width": "40%"
+                    },
+                    "9001_comparator": {
+                      "enumNames": ["等于(布尔)"],
+                      "enum": ["6"],
+                      "ui:hidden": "conditionName!=9001",
+                      "ui:width": "15%"
+                    },
+                    "9001_return_value": {
+                      "enumNames": ["是", "否"],
+                      "enum": ["true", "false"],
+                      "ui:hidden": "conditionName!=9001",
+                      "ui:width": "40%"
+                    },
+                    "9001_params_businessLine": {
+                      "type": "string",
+                      "title": "类目",
+                      "ui:hidden": "conditionName!=9001",
+                      "ui:width": "40%"
+                    },
+                    "9001_params_templateId": {
+                      "type": "string",
+                      "title": "模板Id",
+                      "ui:hidden": "conditionName!=9001",
+                      "ui:width": "40%"
+                    },
+                    "10001_comparator": {
+                      "enumNames": ["等于(布尔)"],
+                      "enum": ["6"],
+                      "ui:hidden": "conditionName!=10001",
+                      "ui:width": "15%"
+                    },
+                    "10001_return_value": {
+                      "enumNames": ["是", "否"],
+                      "enum": ["true", "false"],
+                      "ui:hidden": "conditionName!=10001",
+                      "ui:width": "40%"
+                    },
+                    "20002_comparator": {
+                      "enumNames": ["等于(数值)", "大于（数值）", "小于(数值)"],
+                      "enum": ["1", "9", "12"],
+                      "ui:hidden": "conditionName!=20002",
+                      "ui:width": "15%"
+                    },
+                    "20002_return_value": {
+                      "type": "string",
+                      "ui:hidden": "conditionName!=20002",
+                      "ui:width": "40%"
+                    },
+                    "24001_comparator": {
+                      "enumNames": ["等于(布尔)"],
+                      "enum": ["6"],
+                      "ui:hidden": "conditionName!=24001",
+                      "ui:width": "15%"
+                    },
+                    "24001_return_value": {
+                      "enumNames": ["是", "否"],
+                      "enum": ["true", "false"],
+                      "ui:hidden": "conditionName!=24001",
+                      "ui:width": "40%"
+                    },
+                    "24004_comparator": {
+                      "enumNames": ["等于(数值)", "大于（数值）", "小于(数值)"],
+                      "enum": ["1", "9", "12"],
+                      "ui:hidden": "conditionName!=24004",
+                      "ui:width": "15%"
+                    },
+                    "24004_return_value": {
+                      "enumNames": [
+                        "探亲位移",
+                        "泰国",
+                        "阿联酋",
+                        "菲律宾",
+                        "越南",
+                        "印度尼西亚",
+                        "广州",
+                        "欧盟",
+                        "韩国",
+                        "马来西亚",
+                        "苏州",
+                        "英国",
+                        "旅游位移",
+                        "澳大利亚",
+                        "上海",
+                        "台湾",
+                        "北京",
+                        "美国",
+                        "新加坡位移",
+                        "港澳",
+                        "日本",
+                        "出差位移",
+                        "南京"
+                      ],
+                      "enum": [
+                        "909",
+                        "1022",
+                        "1033",
+                        "1032",
+                        "1031",
+                        "1030",
+                        "1756",
+                        "1018",
+                        "980",
+                        "1029",
+                        "1755",
+                        "1028",
+                        "784",
+                        "1027",
+                        "1753",
+                        "1026",
+                        "1752",
+                        "1025",
+                        "963",
+                        "1024",
+                        "1023",
+                        "910",
+                        "1757"
+                      ],
+                      "ui:hidden": "conditionName!=24004",
+                      "ui:width": "40%"
+                    },
+                    "26001_comparator": {
+                      "enumNames": ["等于(布尔)"],
+                      "enum": ["6"],
+                      "ui:hidden": "conditionName!=26001",
+                      "ui:width": "15%"
+                    },
+                    "26001_return_value": {
+                      "enumNames": ["是", "否"],
+                      "enum": ["true", "false"],
+                      "ui:hidden": "conditionName!=26001",
+                      "ui:width": "40%"
+                    },
+                    "26001_params_channel": {
+                      "type": "string",
+                      "title": "渠道(非必填)",
+                      "ui:hidden": "conditionName!=26001",
+                      "ui:width": "40%"
+                    },
+                    "26001_params_templateId": {
+                      "type": "string",
+                      "title": "卡券模版ID",
+                      "ui:hidden": "conditionName!=26001",
+                      "ui:width": "40%"
+                    },
+                    "27001_comparator": {
+                      "enumNames": [
+                        "等于(数值)",
+                        "大于（数值）",
+                        "大于等于(数值)",
+                        "小于(数值)",
+                        "小于等于(数值)"
+                      ],
+                      "enum": ["1", "9", "10", "12", "14"],
+                      "ui:hidden": "conditionName!=27001",
+                      "ui:width": "15%"
+                    },
+                    "27001_return_value": {
+                      "type": "string",
+                      "ui:hidden": "conditionName!=27001",
+                      "ui:width": "40%"
+                    },
+                    "27002_comparator": {
+                      "enumNames": ["等于(字符)", "不等于(字符)"],
+                      "enum": ["2", "3"],
+                      "ui:hidden": "conditionName!=27002",
+                      "ui:width": "15%"
+                    },
+                    "27002_return_value": {
+                      "enumNames": ["预售支付订单"],
+                      "enum": ["10000-trade-paid-done"],
+                      "ui:hidden": "conditionName!=27002",
+                      "ui:width": "40%"
+                    },
+                    "35001_comparator": {
+                      "enumNames": ["等于(布尔)"],
+                      "enum": ["6"],
+                      "ui:hidden": "conditionName!=35001",
+                      "ui:width": "15%"
+                    },
+                    "35001_return_value": {
+                      "type": "string",
+                      "ui:hidden": "conditionName!=35001",
+                      "ui:width": "40%"
+                    },
+                    "35002_comparator": {
+                      "enumNames": ["等于(布尔)"],
+                      "enum": ["6"],
+                      "ui:hidden": "conditionName!=35002",
+                      "ui:width": "15%"
+                    },
+                    "35002_return_value": {
+                      "type": "string",
+                      "ui:hidden": "conditionName!=35002",
+                      "ui:width": "40%"
+                    },
+                    "36001_comparator": {
+                      "enumNames": ["等于(布尔)"],
+                      "enum": ["6"],
+                      "ui:hidden": "conditionName!=36001",
+                      "ui:width": "15%"
+                    },
+                    "36001_return_value": {
+                      "enumNames": ["是", "否"],
+                      "enum": ["true", "false"],
+                      "ui:hidden": "conditionName!=36001",
+                      "ui:width": "40%"
+                    },
+                    "36001_params_userIdList": {
+                      "type": "string",
+                      "title": "userIdList",
+                      "ui:hidden": "conditionName!=36001",
+                      "ui:width": "40%"
+                    },
+                    "59001_comparator": {
+                      "enumNames": ["等于(布尔)"],
+                      "enum": ["6"],
+                      "ui:hidden": "conditionName!=59001",
+                      "ui:width": "15%"
+                    },
+                    "59001_return_value": {
+                      "enumNames": ["是", "否"],
+                      "enum": ["true", "false"],
+                      "ui:hidden": "conditionName!=59001",
+                      "ui:width": "40%"
+                    },
+                    "59001_params_umpInstanceIds": {
+                      "type": "string",
+                      "title": "ump模板Id",
+                      "ui:hidden": "conditionName!=59001",
+                      "ui:width": "40%"
+                    },
+                    "59002_comparator": {
+                      "enumNames": ["等于(布尔)"],
+                      "enum": ["6"],
+                      "ui:hidden": "conditionName!=59002",
+                      "ui:width": "15%"
+                    },
+                    "59002_return_value": {
+                      "enumNames": ["是", "否"],
+                      "enum": ["true", "false"],
+                      "ui:hidden": "conditionName!=59002",
+                      "ui:width": "40%"
+                    },
+                    "59002_params_umpInstanceIds": {
+                      "type": "string",
+                      "title": "ump模板Id",
+                      "ui:hidden": "conditionName!=59002",
+                      "ui:width": "40%"
+                    },
+                    "60001_comparator": {
+                      "enumNames": ["等于(布尔)"],
+                      "enum": ["6"],
+                      "ui:hidden": "conditionName!=60001",
+                      "ui:width": "15%"
+                    },
+                    "60001_return_value": {
+                      "type": "string",
+                      "ui:hidden": "conditionName!=60001",
+                      "ui:width": "40%"
+                    },
+                    "60001_params_crowdId": {
+                      "type": "string",
+                      "title": "人群ID",
+                      "ui:hidden": "conditionName!=60001",
+                      "ui:width": "40%"
+                    },
+                    "97001_comparator": {
+                      "enumNames": ["大于（数值）", "小于(数值)"],
+                      "enum": ["9", "12"],
+                      "ui:hidden": "conditionName!=97001",
+                      "ui:width": "15%"
+                    },
+                    "97001_return_value": {
+                      "type": "string",
+                      "ui:hidden": "conditionName!=97001",
+                      "ui:width": "40%"
+                    },
+                    "115001_comparator": {
+                      "enumNames": ["等于(布尔)"],
+                      "enum": ["6"],
+                      "ui:hidden": "conditionName!=115001",
+                      "ui:width": "15%"
+                    },
+                    "115001_return_value": {
+                      "enumNames": ["是", "否"],
+                      "enum": ["true", "false"],
+                      "ui:hidden": "conditionName!=115001",
+                      "ui:width": "40%"
+                    },
+                    "116001_comparator": {
+                      "enumNames": ["等于(布尔)"],
+                      "enum": ["6"],
+                      "ui:hidden": "conditionName!=116001",
+                      "ui:width": "15%"
+                    },
+                    "116001_return_value": {
+                      "enumNames": ["是", "否"],
+                      "enum": ["true", "false"],
+                      "ui:hidden": "conditionName!=116001",
+                      "ui:width": "40%"
+                    },
+                    "116001_params_surveyId": {
+                      "type": "string",
+                      "title": "问卷id",
+                      "ui:hidden": "conditionName!=116001",
+                      "ui:width": "40%"
+                    },
+                    "117001_comparator": {
+                      "enumNames": ["等于(布尔)"],
+                      "enum": ["6"],
+                      "ui:hidden": "conditionName!=117001",
+                      "ui:width": "15%"
+                    },
+                    "117001_return_value": {
+                      "enumNames": ["是", "否"],
+                      "enum": ["true", "false"],
+                      "ui:hidden": "conditionName!=117001",
+                      "ui:width": "40%"
+                    },
+                    "117001_params_categoryIdList": {
+                      "type": "string",
+                      "title": "categoryIdList",
+                      "ui:hidden": "conditionName!=117001",
+                      "ui:width": "40%"
+                    },
+                    "131001_comparator": {
+                      "enumNames": ["等于(布尔)"],
+                      "enum": ["6"],
+                      "ui:hidden": "conditionName!=131001",
+                      "ui:width": "15%"
+                    },
+                    "131001_return_value": {
+                      "enumNames": ["是", "否"],
+                      "enum": ["true", "false"],
+                      "ui:hidden": "conditionName!=131001",
+                      "ui:width": "40%"
+                    },
+                    "131001_params_nodeCode": {
+                      "type": "string",
+                      "title": "节点ID",
+                      "ui:hidden": "conditionName!=131001",
+                      "ui:width": "40%"
+                    },
+                    "134001_comparator": {
+                      "enumNames": ["等于(布尔)"],
+                      "enum": ["6"],
+                      "ui:hidden": "conditionName!=134001",
+                      "ui:width": "15%"
+                    },
+                    "134001_return_value": {
+                      "enumNames": ["是", "否"],
+                      "enum": ["true", "false"],
+                      "ui:hidden": "conditionName!=134001",
+                      "ui:width": "40%"
+                    },
+                    "134001_params_umpInstanceIds": {
+                      "type": "string",
+                      "title": "ump模板Id",
+                      "ui:hidden": "conditionName!=134001",
+                      "ui:width": "40%"
+                    },
+                    "169001_comparator": {
+                      "enumNames": ["等于(布尔)"],
+                      "enum": ["6"],
+                      "ui:hidden": "conditionName!=169001",
+                      "ui:width": "15%"
+                    },
+                    "169001_return_value": {
+                      "enumNames": ["是", "否"],
+                      "enum": ["true", "false"],
+                      "ui:hidden": "conditionName!=169001",
+                      "ui:width": "40%"
+                    },
+                    "169001_params_surveyId": {
+                      "type": "string",
+                      "title": "问卷id",
+                      "ui:hidden": "conditionName!=169001",
+                      "ui:width": "40%"
+                    },
+                    "170002_comparator": {
+                      "enumNames": ["等于(布尔)"],
+                      "enum": ["6"],
+                      "ui:hidden": "conditionName!=170002",
+                      "ui:width": "15%"
+                    },
+                    "170002_return_value": {
+                      "enumNames": ["是", "否"],
+                      "enum": ["true", "false"],
+                      "ui:hidden": "conditionName!=170002",
+                      "ui:width": "40%"
+                    },
+                    "173001_comparator": {
+                      "enumNames": ["等于(布尔)"],
+                      "enum": ["6"],
+                      "ui:hidden": "conditionName!=173001",
+                      "ui:width": "15%"
+                    },
+                    "173001_return_value": {
+                      "enumNames": ["是", "否"],
+                      "enum": ["true", "false"],
+                      "ui:hidden": "conditionName!=173001",
+                      "ui:width": "40%"
+                    },
+                    "173001_params_productId": {
+                      "type": "string",
+                      "title": "产品id",
+                      "ui:hidden": "conditionName!=173001",
+                      "ui:width": "40%"
+                    },
+                    "173001_params_crowdId": {
+                      "type": "string",
+                      "title": "人群id",
+                      "ui:hidden": "conditionName!=173001",
+                      "ui:width": "40%"
+                    },
+                    "173001_params_token": {
+                      "type": "string",
+                      "title": "口令",
+                      "ui:hidden": "conditionName!=173001",
+                      "ui:width": "40%"
+                    },
+                    "178001_comparator": {
+                      "enumNames": ["等于(布尔)"],
+                      "enum": ["6"],
+                      "ui:hidden": "conditionName!=178001",
+                      "ui:width": "15%"
+                    },
+                    "178001_return_value": {
+                      "enumNames": ["是", "否"],
+                      "enum": ["true", "false"],
+                      "ui:hidden": "conditionName!=178001",
+                      "ui:width": "40%"
+                    },
+                    "180001_comparator": {
+                      "enumNames": ["大于等于(数值)", "小于等于(数值)"],
+                      "enum": ["10", "14"],
+                      "ui:hidden": "conditionName!=180001",
+                      "ui:width": "15%"
+                    },
+                    "180001_return_value": {
+                      "type": "string",
+                      "ui:hidden": "conditionName!=180001",
+                      "ui:width": "40%"
+                    },
+                    "181001_comparator": {
+                      "enumNames": ["等于(布尔)", "测试比较符管理"],
+                      "enum": ["6", "13001"],
+                      "ui:hidden": "conditionName!=181001",
+                      "ui:width": "15%"
+                    },
+                    "181001_return_value": {
+                      "type": "string",
+                      "ui:hidden": "conditionName!=181001",
+                      "ui:width": "40%"
+                    },
+                    "181001_params_hidList": {
+                      "type": "string",
+                      "title": "酒店hid列表",
+                      "ui:hidden": "conditionName!=181001",
+                      "ui:width": "40%"
+                    },
+                    "182001_comparator": {
+                      "enumNames": ["等于(布尔)"],
+                      "enum": ["6"],
+                      "ui:hidden": "conditionName!=182001",
+                      "ui:width": "15%"
+                    },
+                    "182001_return_value": {
+                      "type": "string",
+                      "ui:hidden": "conditionName!=182001",
+                      "ui:width": "40%"
+                    },
+                    "182001_params_sellerIdList": {
+                      "type": "string",
+                      "title": "卖家ID名单",
+                      "ui:hidden": "conditionName!=182001",
+                      "ui:width": "40%"
+                    },
+                    "182002_comparator": {
+                      "enumNames": ["等于(布尔)", "测试比较符管理"],
+                      "enum": ["6", "13001"],
+                      "ui:hidden": "conditionName!=182002",
+                      "ui:width": "15%"
+                    },
+                    "182002_return_value": {
+                      "type": "string",
+                      "ui:hidden": "conditionName!=182002",
+                      "ui:width": "40%"
+                    },
+                    "182002_params_checkInDate2": {
+                      "type": "string",
+                      "title": "yyyy-MM-dd HH:mm:ss",
+                      "ui:hidden": "conditionName!=182002",
+                      "ui:width": "40%"
+                    },
+                    "183001_comparator": {
+                      "enumNames": ["等于(布尔)", "测试比较符管理"],
+                      "enum": ["6", "13001"],
+                      "ui:hidden": "conditionName!=183001",
+                      "ui:width": "15%"
+                    },
+                    "183001_return_value": {
+                      "type": "string",
+                      "ui:hidden": "conditionName!=183001",
+                      "ui:width": "40%"
+                    },
+                    "183001_params_checkOutDate2": {
+                      "type": "string",
+                      "title": "yyyy-MM-dd HH:mm:ss",
+                      "ui:hidden": "conditionName!=183001",
+                      "ui:width": "40%"
+                    },
+                    "184001_comparator": {
+                      "enumNames": ["等于(布尔)", "测试比较符管理"],
+                      "enum": ["6", "13001"],
+                      "ui:hidden": "conditionName!=184001",
+                      "ui:width": "15%"
+                    },
+                    "184001_return_value": {
+                      "type": "string",
+                      "ui:hidden": "conditionName!=184001",
+                      "ui:width": "40%"
+                    },
+                    "184001_params_checkInDate2": {
+                      "type": "string",
+                      "title": "yyyy-MM-dd HH:mm:ss",
+                      "ui:hidden": "conditionName!=184001",
+                      "ui:width": "40%"
+                    },
+                    "185001_comparator": {
+                      "enumNames": ["等于(布尔)", "测试比较符管理"],
+                      "enum": ["6", "13001"],
+                      "ui:hidden": "conditionName!=185001",
+                      "ui:width": "15%"
+                    },
+                    "185001_return_value": {
+                      "type": "string",
+                      "ui:hidden": "conditionName!=185001",
+                      "ui:width": "40%"
+                    },
+                    "185001_params_orderCreateDate2": {
+                      "type": "string",
+                      "title": "yyyy-MM-dd HH:mm:ss",
+                      "ui:hidden": "conditionName!=185001",
+                      "ui:width": "40%"
+                    },
+                    "186001_comparator": {
+                      "enumNames": ["等于(布尔)", "测试比较符管理"],
+                      "enum": ["6", "13001"],
+                      "ui:hidden": "conditionName!=186001",
+                      "ui:width": "15%"
+                    },
+                    "186001_return_value": {
+                      "type": "string",
+                      "ui:hidden": "conditionName!=186001",
+                      "ui:width": "40%"
+                    },
+                    "186001_params_orderCreateDate2": {
+                      "type": "string",
+                      "title": "yyyy-MM-dd HH:mm:ss",
+                      "ui:hidden": "conditionName!=186001",
+                      "ui:width": "40%"
+                    },
+                    "187001_comparator": {
+                      "enumNames": ["等于(布尔)", "测试比较符管理"],
+                      "enum": ["6", "13001"],
+                      "ui:hidden": "conditionName!=187001",
+                      "ui:width": "15%"
+                    },
+                    "187001_return_value": {
+                      "enumNames": ["是", "否"],
+                      "enum": ["true", "false"],
+                      "ui:hidden": "conditionName!=187001",
+                      "ui:width": "40%"
+                    },
+                    "188001_comparator": {
+                      "enumNames": ["等于(布尔)", "测试比较符管理"],
+                      "enum": ["6", "13001"],
+                      "ui:hidden": "conditionName!=188001",
+                      "ui:width": "15%"
+                    },
+                    "188001_return_value": {
+                      "enumNames": ["是", "否"],
+                      "enum": ["true", "false"],
+                      "ui:hidden": "conditionName!=188001",
+                      "ui:width": "40%"
+                    },
+                    "189001_comparator": {
+                      "enumNames": ["等于(布尔)", "测试比较符管理"],
+                      "enum": ["6", "13001"],
+                      "ui:hidden": "conditionName!=189001",
+                      "ui:width": "15%"
+                    },
+                    "189001_return_value": {
+                      "enumNames": ["是", "否"],
+                      "enum": ["true", "false"],
+                      "ui:hidden": "conditionName!=189001",
+                      "ui:width": "40%"
+                    },
+                    "194001_comparator": {
+                      "enumNames": ["等于(布尔)", "测试比较符管理"],
+                      "enum": ["6", "13001"],
+                      "ui:hidden": "conditionName!=194001",
+                      "ui:width": "15%"
+                    },
+                    "194001_return_value": {
+                      "enumNames": ["是", "否"],
+                      "enum": ["true", "false"],
+                      "ui:hidden": "conditionName!=194001",
+                      "ui:width": "40%"
+                    },
+                    "200001_comparator": {
+                      "enumNames": ["等于(布尔)"],
+                      "enum": ["6"],
+                      "ui:hidden": "conditionName!=200001",
+                      "ui:width": "15%"
+                    },
+                    "200001_return_value": {
+                      "type": "string",
+                      "ui:hidden": "conditionName!=200001",
+                      "ui:width": "40%"
+                    },
+                    "200001_params_tailPaidDate3": {
+                      "type": "string",
+                      "title": "yyyy-MM-dd HH:mm:ss",
+                      "ui:hidden": "conditionName!=200001",
+                      "ui:width": "40%"
+                    },
+                    "201001_comparator": {
+                      "enumNames": ["等于(布尔)", "测试比较符管理"],
+                      "enum": ["6", "13001"],
+                      "ui:hidden": "conditionName!=201001",
+                      "ui:width": "15%"
+                    },
+                    "201001_return_value": {
+                      "type": "string",
+                      "ui:hidden": "conditionName!=201001",
+                      "ui:width": "40%"
+                    },
+                    "201001_params_tailPaidDate2": {
+                      "type": "string",
+                      "title": "yyyy-MM-dd HH:mm:ss",
+                      "ui:hidden": "conditionName!=201001",
+                      "ui:width": "40%"
+                    },
+                    "207001_comparator": {
+                      "enumNames": ["等于(布尔)"],
+                      "enum": ["6"],
+                      "ui:hidden": "conditionName!=207001",
+                      "ui:width": "15%"
+                    },
+                    "207001_return_value": {
+                      "enumNames": ["是", "否"],
+                      "enum": ["true", "false"],
+                      "ui:hidden": "conditionName!=207001",
+                      "ui:width": "40%"
+                    },
+                    "208001_comparator": {
+                      "enumNames": ["等于(布尔)"],
+                      "enum": ["6"],
+                      "ui:hidden": "conditionName!=208001",
+                      "ui:width": "15%"
+                    },
+                    "208001_return_value": {
+                      "enumNames": ["是", "否"],
+                      "enum": ["true", "false"],
+                      "ui:hidden": "conditionName!=208001",
+                      "ui:width": "40%"
+                    },
+                    "212001_comparator": {
+                      "enumNames": [
+                        "等于(数值)",
+                        "大于（数值）",
+                        "大于等于(数值)",
+                        "小于(数值)",
+                        "小于等于(数值)",
+                        "不等于（数值）"
+                      ],
+                      "enum": ["1", "9", "10", "12", "14", "12001"],
+                      "ui:hidden": "conditionName!=212001",
+                      "ui:width": "15%"
+                    },
+                    "212001_return_value": {
+                      "type": "string",
+                      "ui:hidden": "conditionName!=212001",
+                      "ui:width": "40%"
+                    },
+                    "212001_params_virtralCode": {
+                      "type": "string",
+                      "title": "虚拟积分ID",
+                      "ui:hidden": "conditionName!=212001",
+                      "ui:width": "40%"
+                    },
+                    "213001_comparator": {
+                      "enumNames": [
+                        "等于(数值)",
+                        "大于（数值）",
+                        "大于等于(数值)",
+                        "小于(数值)",
+                        "小于等于(数值)",
+                        "不等于（数值）"
+                      ],
+                      "enum": ["1", "9", "10", "12", "14", "12001"],
+                      "ui:hidden": "conditionName!=213001",
+                      "ui:width": "15%"
+                    },
+                    "213001_return_value": {
+                      "type": "string",
+                      "ui:hidden": "conditionName!=213001",
+                      "ui:width": "40%"
+                    },
+                    "213001_params_vendor": {
+                      "type": "string",
+                      "title": "供应商",
+                      "ui:hidden": "conditionName!=213001",
+                      "ui:width": "40%"
+                    },
+                    "213001_params_partnerId": {
+                      "type": "string",
+                      "title": "伙伴ID",
+                      "ui:hidden": "conditionName!=213001",
+                      "ui:width": "40%"
+                    },
+                    "215001_comparator": {
+                      "enumNames": ["等于(布尔)"],
+                      "enum": ["6"],
+                      "ui:hidden": "conditionName!=215001",
+                      "ui:width": "15%"
+                    },
+                    "215001_return_value": {
+                      "type": "string",
+                      "ui:hidden": "conditionName!=215001",
+                      "ui:width": "40%"
+                    },
+                    "215001_params_payTime4PointDouble2": {
+                      "type": "string",
+                      "title": "yyyy-MM-dd HH:mm:ss",
+                      "ui:hidden": "conditionName!=215001",
+                      "ui:width": "40%"
+                    },
+                    "216001_comparator": {
+                      "enumNames": ["等于(布尔)"],
+                      "enum": ["6"],
+                      "ui:hidden": "conditionName!=216001",
+                      "ui:width": "15%"
+                    },
+                    "216001_return_value": {
+                      "type": "string",
+                      "ui:hidden": "conditionName!=216001",
+                      "ui:width": "40%"
+                    },
+                    "216001_params_payTime4PointDouble3": {
+                      "type": "string",
+                      "title": "yyyy-MM-dd HH:mm:ss",
+                      "ui:hidden": "conditionName!=216001",
+                      "ui:width": "40%"
+                    },
+                    "219001_comparator": {
+                      "enumNames": ["等于(布尔)"],
+                      "enum": ["6"],
+                      "ui:hidden": "conditionName!=219001",
+                      "ui:width": "15%"
+                    },
+                    "219001_return_value": {
+                      "enumNames": ["是", "否"],
+                      "enum": ["true", "false"],
+                      "ui:hidden": "conditionName!=219001",
+                      "ui:width": "40%"
+                    },
+                    "220001_comparator": {
+                      "enumNames": ["等于(布尔)"],
+                      "enum": ["6"],
+                      "ui:hidden": "conditionName!=220001",
+                      "ui:width": "15%"
+                    },
+                    "220001_return_value": {
+                      "enumNames": ["是", "否"],
+                      "enum": ["true", "false"],
+                      "ui:hidden": "conditionName!=220001",
+                      "ui:width": "40%"
+                    },
+                    "221001_comparator": {
+                      "enumNames": [
+                        "等于(数值)",
+                        "大于（数值）",
+                        "大于等于(数值)",
+                        "小于(数值)"
+                      ],
+                      "enum": ["1", "9", "10", "12"],
+                      "ui:hidden": "conditionName!=221001",
+                      "ui:width": "15%"
+                    },
+                    "221001_return_value": {
+                      "type": "string",
+                      "ui:hidden": "conditionName!=221001",
+                      "ui:width": "40%"
+                    },
+                    "221001_params_virtualCode": {
+                      "type": "string",
+                      "title": "虚拟积分id",
+                      "ui:hidden": "conditionName!=221001",
+                      "ui:width": "40%"
+                    },
+                    "222001_comparator": {
+                      "enumNames": [
+                        "等于(数值)",
+                        "大于（数值）",
+                        "大于等于(数值)",
+                        "小于(数值)",
+                        "小于等于(数值)"
+                      ],
+                      "enum": ["1", "9", "10", "12", "14"],
+                      "ui:hidden": "conditionName!=222001",
+                      "ui:width": "15%"
+                    },
+                    "222001_return_value": {
+                      "type": "string",
+                      "ui:hidden": "conditionName!=222001",
+                      "ui:width": "40%"
+                    },
+                    "222001_params_virtualCode": {
+                      "type": "string",
+                      "title": "虚拟积分id",
+                      "ui:hidden": "conditionName!=222001",
+                      "ui:width": "40%"
+                    },
+                    "223001_comparator": {
+                      "enumNames": ["等于(布尔)"],
+                      "enum": ["6"],
+                      "ui:hidden": "conditionName!=223001",
+                      "ui:width": "15%"
+                    },
+                    "223001_return_value": {
+                      "type": "string",
+                      "ui:hidden": "conditionName!=223001",
+                      "ui:width": "40%"
+                    },
+                    "223001_params_subActId": {
+                      "type": "string",
+                      "title": "活动id",
+                      "ui:hidden": "conditionName!=223001",
+                      "ui:width": "40%"
+                    },
+                    "223001_params_groupResourceId": {
+                      "type": "string",
+                      "title": "资源组id",
+                      "ui:hidden": "conditionName!=223001",
+                      "ui:width": "40%"
+                    },
+                    "224001_comparator": {
+                      "enumNames": [
+                        "等于(数值)",
+                        "大于（数值）",
+                        "大于等于(数值)",
+                        "小于(数值)",
+                        "小于等于(数值)",
+                        "不等于（数值）"
+                      ],
+                      "enum": ["1", "9", "10", "12", "14", "12001"],
+                      "ui:hidden": "conditionName!=224001",
+                      "ui:width": "15%"
+                    },
+                    "224001_return_value": {
+                      "type": "string",
+                      "ui:hidden": "conditionName!=224001",
+                      "ui:width": "40%"
+                    },
+                    "224001_params_virtualCode": {
+                      "type": "string",
+                      "title": "虚拟积分id",
+                      "ui:hidden": "conditionName!=224001",
+                      "ui:width": "40%"
+                    },
+                    "224001_params_virtualValue": {
+                      "type": "string",
+                      "title": "本次新增积分",
+                      "ui:hidden": "conditionName!=224001",
+                      "ui:width": "40%"
+                    },
+                    "225001_comparator": {
+                      "enumNames": ["等于(布尔)"],
+                      "enum": ["6"],
+                      "ui:hidden": "conditionName!=225001",
+                      "ui:width": "15%"
+                    },
+                    "225001_return_value": {
+                      "enumNames": ["是", "否"],
+                      "enum": ["true", "false"],
+                      "ui:hidden": "conditionName!=225001",
+                      "ui:width": "40%"
+                    },
+                    "225001_params_subActId": {
+                      "type": "string",
+                      "title": "subActId",
+                      "ui:hidden": "conditionName!=225001",
+                      "ui:width": "40%"
+                    },
+                    "226001_comparator": {
+                      "enumNames": ["等于(布尔)", "测试比较符管理"],
+                      "enum": ["6", "13001"],
+                      "ui:hidden": "conditionName!=226001",
+                      "ui:width": "15%"
+                    },
+                    "226001_return_value": {
+                      "enumNames": ["是", "否"],
+                      "enum": ["true", "false"],
+                      "ui:hidden": "conditionName!=226001",
+                      "ui:width": "40%"
+                    },
+                    "229001_comparator": {
+                      "enumNames": ["等于(布尔)"],
+                      "enum": ["6"],
+                      "ui:hidden": "conditionName!=229001",
+                      "ui:width": "15%"
+                    },
+                    "229001_return_value": {
+                      "enumNames": ["是", "否"],
+                      "enum": ["true", "false"],
+                      "ui:hidden": "conditionName!=229001",
+                      "ui:width": "40%"
+                    },
+                    "229001_params_sellerId": {
+                      "type": "string",
+                      "title": "sellerId",
+                      "ui:hidden": "conditionName!=229001",
+                      "ui:width": "40%"
+                    },
+                    "229001_params_templateCode": {
+                      "type": "string",
+                      "title": "templateCode",
+                      "ui:hidden": "conditionName!=229001",
+                      "ui:width": "40%"
+                    },
+                    "230002_comparator": {
+                      "enumNames": ["等于(布尔)"],
+                      "enum": ["6"],
+                      "ui:hidden": "conditionName!=230002",
+                      "ui:width": "15%"
+                    },
+                    "230002_return_value": {
+                      "enumNames": ["是", "否"],
+                      "enum": ["true", "false"],
+                      "ui:hidden": "conditionName!=230002",
+                      "ui:width": "40%"
+                    },
+                    "230002_params_userIdList": {
+                      "type": "string",
+                      "title": "userIdList",
+                      "ui:hidden": "conditionName!=230002",
+                      "ui:width": "40%"
+                    },
+                    "231001_comparator": {
+                      "enumNames": ["等于(布尔)", "测试比较符管理"],
+                      "enum": ["6", "13001"],
+                      "ui:hidden": "conditionName!=231001",
+                      "ui:width": "15%"
+                    },
+                    "231001_return_value": {
+                      "enumNames": ["是", "否"],
+                      "enum": ["true", "false"],
+                      "ui:hidden": "conditionName!=231001",
+                      "ui:width": "40%"
+                    },
+                    "231001_params_templateId": {
+                      "type": "string",
+                      "title": "ump模板ID",
+                      "ui:hidden": "conditionName!=231001",
+                      "ui:width": "40%"
+                    },
+                    "232001_comparator": {
+                      "enumNames": ["等于(布尔)"],
+                      "enum": ["6"],
+                      "ui:hidden": "conditionName!=232001",
+                      "ui:width": "15%"
+                    },
+                    "232001_return_value": {
+                      "enumNames": ["是", "否"],
+                      "enum": ["true", "false"],
+                      "ui:hidden": "conditionName!=232001",
+                      "ui:width": "40%"
+                    },
+                    "232001_params_subActIdList": {
+                      "type": "string",
+                      "title": "活动id(英文逗号隔开)",
+                      "ui:hidden": "conditionName!=232001",
+                      "ui:width": "40%"
+                    },
+                    "234001_comparator": {
+                      "enumNames": [
+                        "等于(数值)",
+                        "大于（数值）",
+                        "大于等于(数值)",
+                        "小于(数值)",
+                        "小于等于(数值)"
+                      ],
+                      "enum": ["1", "9", "10", "12", "14"],
+                      "ui:hidden": "conditionName!=234001",
+                      "ui:width": "15%"
+                    },
+                    "234001_return_value": {
+                      "type": "string",
+                      "ui:hidden": "conditionName!=234001",
+                      "ui:width": "40%"
+                    },
+                    "234002_comparator": {
+                      "enumNames": [
+                        "等于(数值)",
+                        "大于（数值）",
+                        "大于等于(数值)",
+                        "小于(数值)",
+                        "小于等于(数值)",
+                        "不等于（数值）"
+                      ],
+                      "enum": ["1", "9", "10", "12", "14", "12001"],
+                      "ui:hidden": "conditionName!=234002",
+                      "ui:width": "15%"
+                    },
+                    "234002_return_value": {
+                      "type": "string",
+                      "ui:hidden": "conditionName!=234002",
+                      "ui:width": "40%"
+                    },
+                    "235001_comparator": {
+                      "enumNames": ["等于(布尔)"],
+                      "enum": ["6"],
+                      "ui:hidden": "conditionName!=235001",
+                      "ui:width": "15%"
+                    },
+                    "235001_return_value": {
+                      "enumNames": ["是", "否"],
+                      "enum": ["true", "false"],
+                      "ui:hidden": "conditionName!=235001",
+                      "ui:width": "40%"
+                    },
+                    "235002_comparator": {
+                      "enumNames": ["等于(布尔)"],
+                      "enum": ["6"],
+                      "ui:hidden": "conditionName!=235002",
+                      "ui:width": "15%"
+                    },
+                    "235002_return_value": {
+                      "enumNames": ["是", "否"],
+                      "enum": ["true", "false"],
+                      "ui:hidden": "conditionName!=235002",
+                      "ui:width": "40%"
+                    },
+                    "236001_comparator": {
+                      "enumNames": ["等于(布尔)"],
+                      "enum": ["6"],
+                      "ui:hidden": "conditionName!=236001",
+                      "ui:width": "15%"
+                    },
+                    "236001_return_value": {
+                      "enumNames": ["是", "否"],
+                      "enum": ["true", "false"],
+                      "ui:hidden": "conditionName!=236001",
+                      "ui:width": "40%"
+                    },
+                    "237001_comparator": {
+                      "enumNames": ["等于(布尔)"],
+                      "enum": ["6"],
+                      "ui:hidden": "conditionName!=237001",
+                      "ui:width": "15%"
+                    },
+                    "237001_return_value": {
+                      "enumNames": ["是", "否"],
+                      "enum": ["true", "false"],
+                      "ui:hidden": "conditionName!=237001",
+                      "ui:width": "40%"
+                    },
+                    "238001_comparator": {
+                      "enumNames": ["等于(布尔)"],
+                      "enum": ["6"],
+                      "ui:hidden": "conditionName!=238001",
+                      "ui:width": "15%"
+                    },
+                    "238001_return_value": {
+                      "enumNames": ["是", "否"],
+                      "enum": ["true", "false"],
+                      "ui:hidden": "conditionName!=238001",
+                      "ui:width": "40%"
+                    },
+                    "239001_comparator": {
+                      "enumNames": ["等于(布尔)"],
+                      "enum": ["6"],
+                      "ui:hidden": "conditionName!=239001",
+                      "ui:width": "15%"
+                    },
+                    "239001_return_value": {
+                      "enumNames": ["是", "否"],
+                      "enum": ["true", "false"],
+                      "ui:hidden": "conditionName!=239001",
+                      "ui:width": "40%"
+                    },
+                    "240001_comparator": {
+                      "enumNames": ["等于(布尔)"],
+                      "enum": ["6"],
+                      "ui:hidden": "conditionName!=240001",
+                      "ui:width": "15%"
+                    },
+                    "240001_return_value": {
+                      "enumNames": ["是", "否"],
+                      "enum": ["true", "false"],
+                      "ui:hidden": "conditionName!=240001",
+                      "ui:width": "40%"
+                    },
+                    "241001_comparator": {
+                      "enumNames": ["等于(布尔)"],
+                      "enum": ["6"],
+                      "ui:hidden": "conditionName!=241001",
+                      "ui:width": "15%"
+                    },
+                    "241001_return_value": {
+                      "enumNames": ["是", "否"],
+                      "enum": ["true", "false"],
+                      "ui:hidden": "conditionName!=241001",
+                      "ui:width": "40%"
+                    },
+                    "241001_params_subActTemplatedId": {
+                      "type": "string",
+                      "title": "模版Id",
+                      "ui:hidden": "conditionName!=241001",
+                      "ui:width": "40%"
+                    },
+                    "244001_comparator": {
+                      "enumNames": ["等于(布尔)"],
+                      "enum": ["6"],
+                      "ui:hidden": "conditionName!=244001",
+                      "ui:width": "15%"
+                    },
+                    "244001_return_value": {
+                      "enumNames": ["是", "否"],
+                      "enum": ["true", "false"],
+                      "ui:hidden": "conditionName!=244001",
+                      "ui:width": "40%"
+                    },
+                    "244001_params_templateId": {
+                      "type": "string",
+                      "title": "ump模板ID",
+                      "ui:hidden": "conditionName!=244001",
+                      "ui:width": "40%"
+                    },
+                    "245001_comparator": {
+                      "enumNames": ["等于(布尔)", "测试比较符管理"],
+                      "enum": ["6", "13001"],
+                      "ui:hidden": "conditionName!=245001",
+                      "ui:width": "15%"
+                    },
+                    "245001_return_value": {
+                      "enumNames": ["是", "否"],
+                      "enum": ["true", "false"],
+                      "ui:hidden": "conditionName!=245001",
+                      "ui:width": "40%"
+                    },
+                    "245001_params_whiteItemIdList": {
+                      "type": "string",
+                      "title": "商品Id白名单列表（多个用逗号分割）",
+                      "ui:hidden": "conditionName!=245001",
+                      "ui:width": "40%"
+                    },
+                    "250001_comparator": {
+                      "enumNames": ["等于(数值)"],
+                      "enum": ["1"],
+                      "ui:hidden": "conditionName!=250001",
+                      "ui:width": "15%"
+                    },
+                    "250001_return_value": {
+                      "enumNames": ["没有", "有"],
+                      "enum": ["0", "1"],
+                      "ui:hidden": "conditionName!=250001",
+                      "ui:width": "40%"
+                    },
+                    "250001_params_templateIds": {
+                      "type": "string",
+                      "title": "templateIds",
+                      "ui:hidden": "conditionName!=250001",
+                      "ui:width": "40%"
+                    },
+                    "251001_comparator": {
+                      "enumNames": ["等于(布尔)", "测试比较符管理"],
+                      "enum": ["6", "13001"],
+                      "ui:hidden": "conditionName!=251001",
+                      "ui:width": "15%"
+                    },
+                    "251001_return_value": {
+                      "enumNames": ["是", "否"],
+                      "enum": ["true", "false"],
+                      "ui:hidden": "conditionName!=251001",
+                      "ui:width": "40%"
+                    },
+                    "251001_params_tpOrderList": {
+                      "type": "string",
+                      "title": "订单号list",
+                      "ui:hidden": "conditionName!=251001",
+                      "ui:width": "40%"
+                    },
+                    "251002_comparator": {
+                      "enumNames": ["等于(布尔)", "测试比较符管理"],
+                      "enum": ["6", "13001"],
+                      "ui:hidden": "conditionName!=251002",
+                      "ui:width": "15%"
+                    },
+                    "251002_return_value": {
+                      "enumNames": ["是", "否"],
+                      "enum": ["true", "false"],
+                      "ui:hidden": "conditionName!=251002",
+                      "ui:width": "40%"
+                    },
+                    "251002_params_whiteOrderPayTime": {
+                      "type": "string",
+                      "title": "支付完成限制时间",
+                      "ui:hidden": "conditionName!=251002",
+                      "ui:width": "40%"
+                    },
+                    "251002_params_whiteCategoryList": {
+                      "type": "string",
+                      "title": "叶子类目白名单",
+                      "ui:hidden": "conditionName!=251002",
+                      "ui:width": "40%"
+                    },
+                    "252001_comparator": {
+                      "enumNames": ["等于(布尔)"],
+                      "enum": ["6"],
+                      "ui:hidden": "conditionName!=252001",
+                      "ui:width": "15%"
+                    },
+                    "252001_return_value": {
+                      "enumNames": ["是", "否"],
+                      "enum": ["true", "false"],
+                      "ui:hidden": "conditionName!=252001",
+                      "ui:width": "40%"
+                    },
+                    "252001_params_whiteItemTags": {
+                      "type": "string",
+                      "title": "商品上的itemTag白名单（多个用逗号分割）",
+                      "ui:hidden": "conditionName!=252001",
+                      "ui:width": "40%"
+                    },
+                    "253001_comparator": {
+                      "enumNames": ["等于(数值)"],
+                      "enum": ["1"],
+                      "ui:hidden": "conditionName!=253001",
+                      "ui:width": "15%"
+                    },
+                    "253001_return_value": {
+                      "enumNames": ["否", "是"],
+                      "enum": ["0", "1"],
+                      "ui:hidden": "conditionName!=253001",
+                      "ui:width": "40%"
+                    },
+                    "255001_comparator": {
+                      "enumNames": ["等于(布尔)", "测试比较符管理"],
+                      "enum": ["6", "13001"],
+                      "ui:hidden": "conditionName!=255001",
+                      "ui:width": "15%"
+                    },
+                    "255001_return_value": {
+                      "enumNames": ["是", "否"],
+                      "enum": ["true", "false"],
+                      "ui:hidden": "conditionName!=255001",
+                      "ui:width": "40%"
+                    },
+                    "257001_comparator": {
+                      "enumNames": [
+                        "等于(数值)",
+                        "大于（数值）",
+                        "大于等于(数值)",
+                        "小于(数值)",
+                        "小于等于(数值)",
+                        "不等于（数值）"
+                      ],
+                      "enum": ["1", "9", "10", "12", "14", "12001"],
+                      "ui:hidden": "conditionName!=257001",
+                      "ui:width": "15%"
+                    },
+                    "257001_return_value": {
+                      "type": "string",
+                      "ui:hidden": "conditionName!=257001",
+                      "ui:width": "40%"
+                    },
+                    "258001_comparator": {
+                      "enumNames": [
+                        "等于(数值)",
+                        "大于（数值）",
+                        "大于等于(数值)",
+                        "小于(数值)",
+                        "小于等于(数值)",
+                        "不等于（数值）"
+                      ],
+                      "enum": ["1", "9", "10", "12", "14", "12001"],
+                      "ui:hidden": "conditionName!=258001",
+                      "ui:width": "15%"
+                    },
+                    "258001_return_value": {
+                      "type": "string",
+                      "ui:hidden": "conditionName!=258001",
+                      "ui:width": "40%"
+                    },
+                    "258001_params_bizType": {
+                      "type": "string",
+                      "title": "bizType",
+                      "ui:hidden": "conditionName!=258001",
+                      "ui:width": "40%"
+                    },
+                    "259001_comparator": {
+                      "enumNames": ["等于(布尔)", "测试比较符管理"],
+                      "enum": ["6", "13001"],
+                      "ui:hidden": "conditionName!=259001",
+                      "ui:width": "15%"
+                    },
+                    "259001_return_value": {
+                      "enumNames": ["是", "否"],
+                      "enum": ["true", "false"],
+                      "ui:hidden": "conditionName!=259001",
+                      "ui:width": "40%"
+                    },
+                    "261001_comparator": {
+                      "enumNames": ["等于(布尔)"],
+                      "enum": ["6"],
+                      "ui:hidden": "conditionName!=261001",
+                      "ui:width": "15%"
+                    },
+                    "261001_return_value": {
+                      "enumNames": ["是", "否"],
+                      "enum": ["true", "false"],
+                      "ui:hidden": "conditionName!=261001",
+                      "ui:width": "40%"
+                    },
+                    "261001_params_templateIds": {
+                      "type": "string",
+                      "title": "券模版Id（多个用逗号分割）",
+                      "ui:hidden": "conditionName!=261001",
+                      "ui:width": "40%"
+                    },
+                    "271001_comparator": {
+                      "enumNames": ["等于(数值)"],
+                      "enum": ["1"],
+                      "ui:hidden": "conditionName!=271001",
+                      "ui:width": "15%"
+                    },
+                    "271001_return_value": {
+                      "type": "string",
+                      "ui:hidden": "conditionName!=271001",
+                      "ui:width": "40%"
+                    },
+                    "273001_comparator": {
+                      "enumNames": ["等于(数值)"],
+                      "enum": ["1"],
+                      "ui:hidden": "conditionName!=273001",
+                      "ui:width": "15%"
+                    },
+                    "273001_return_value": {
+                      "enumNames": ["否", "是"],
+                      "enum": ["0", "1"],
+                      "ui:hidden": "conditionName!=273001",
+                      "ui:width": "40%"
+                    },
+                    "281001_comparator": {
+                      "enumNames": ["等于(布尔)"],
+                      "enum": ["6"],
+                      "ui:hidden": "conditionName!=281001",
+                      "ui:width": "15%"
+                    },
+                    "281001_return_value": {
+                      "enumNames": ["是", "否"],
+                      "enum": ["true", "false"],
+                      "ui:hidden": "conditionName!=281001",
+                      "ui:width": "40%"
+                    },
+                    "281001_params_templateId": {
+                      "type": "string",
+                      "title": "飞猪日常卡模板",
+                      "ui:hidden": "conditionName!=281001",
+                      "ui:width": "40%"
+                    },
+                    "285001_comparator": {
+                      "enumNames": ["等于(数值)"],
+                      "enum": ["1"],
+                      "ui:hidden": "conditionName!=285001",
+                      "ui:width": "15%"
+                    },
+                    "285001_return_value": {
+                      "enumNames": ["否", "是"],
+                      "enum": ["0", "1"],
+                      "ui:hidden": "conditionName!=285001",
+                      "ui:width": "40%"
+                    },
+                    "285001_params_crowdIds": {
+                      "type": "string",
+                      "title": "crowdIds",
+                      "ui:hidden": "conditionName!=285001",
+                      "ui:width": "40%"
+                    },
+                    "286001_comparator": {
+                      "enumNames": [
+                        "等于(数值)",
+                        "大于（数值）",
+                        "大于等于(数值)",
+                        "小于(数值)",
+                        "小于等于(数值)",
+                        "不等于（数值）"
+                      ],
+                      "enum": ["1", "9", "10", "12", "14", "12001"],
+                      "ui:hidden": "conditionName!=286001",
+                      "ui:width": "15%"
+                    },
+                    "286001_return_value": {
+                      "type": "string",
+                      "ui:hidden": "conditionName!=286001",
+                      "ui:width": "40%"
+                    },
+                    "286001_params_crowdIds": {
+                      "type": "string",
+                      "title": "crowdIds",
+                      "ui:hidden": "conditionName!=286001",
+                      "ui:width": "40%"
+                    },
+                    "289001_comparator": {
+                      "enumNames": [
+                        "等于(数值)",
+                        "大于（数值）",
+                        "大于等于(数值)",
+                        "小于(数值)",
+                        "小于等于(数值)",
+                        "不等于（数值）"
+                      ],
+                      "enum": ["1", "9", "10", "12", "14", "12001"],
+                      "ui:hidden": "conditionName!=289001",
+                      "ui:width": "15%"
+                    },
+                    "289001_return_value": {
+                      "enumNames": [
+                        "F0",
+                        "F1(原F1)",
+                        "F2(新F1+)",
+                        "F3(原F2)",
+                        "F4(原F3)"
+                      ],
+                      "enum": ["0", "1", "2", "3", "4"],
+                      "ui:hidden": "conditionName!=289001",
+                      "ui:width": "40%"
+                    },
+                    "291001_comparator": {
+                      "enumNames": [
+                        "等于(数值)",
+                        "大于（数值）",
+                        "大于等于(数值)",
+                        "小于(数值)",
+                        "小于等于(数值)",
+                        "在区间中（数值，闭区间）",
+                        "不等于（数值）",
+                        "StringList包含一个对象"
+                      ],
+                      "enum": [
+                        "1",
+                        "9",
+                        "10",
+                        "12",
+                        "14",
+                        "22",
+                        "12001",
+                        "14001"
+                      ],
+                      "ui:hidden": "conditionName!=291001",
+                      "ui:width": "15%"
+                    },
+                    "291001_return_value": {
+                      "enumNames": ["没有", "有"],
+                      "enum": ["0", "1"],
+                      "ui:hidden": "conditionName!=291001",
+                      "ui:width": "40%"
+                    },
+                    "291001_params_templateIds": {
+                      "type": "string",
+                      "title": "模版id（逗号分隔）",
+                      "ui:hidden": "conditionName!=291001",
+                      "ui:width": "40%"
+                    }
+                  },
+                  "type": "object",
+                  "required": [],
+                  "name": "ruleCondition"
+                }
+              },
+              "actionId": {
+                "title": "动作",
+                "description": "",
+                "type": "string",
+                "enum": "{{formData.prizeGroupConfigList.prizeGroupList.map(obj => obj && obj.groupId ? obj.groupId.toString() : '$New' + obj.name)}}",
+                "enumNames": "{{formData.prizeGroupConfigList.prizeGroupList.map(obj => obj.name)}}",
+                "ui:hidden": "@formData.wfCommonInfo.productCode=='ACCUMULATED'"
+              }
+            },
+            "type": "object",
+            "required": ["ruleDesc", "unMatchNotice", "actionId"],
+            "name": "prizeSendRuleCfg"
+          },
+          "ui:options": { "foldable": true }
+        }
+      },
+      "type": "object",
+      "required": [],
+      "title": "动态规则列表",
+      "name": "prizeSendRuleList"
+    },
+    "applyGiftPackageShowConfig": {
+      "properties": {
+        "template": {
+          "title": "模板",
+          "description": "",
+          "type": "string",
+          "enum": ["1", "2", "3", "4"],
+          "enumNames": [
+            "非会场通用模板",
+            "会场模板",
+            "会场素材模板(弹窗表达)",
+            "支付宝消费券及推荐模板(券库同步专用，慎选)"
+          ],
+          "default": "1",
+          "ui:disabled": "@formData.wfCommonInfo.theTwoEditors===true"
+        },
+        "giftPkgName": {
+          "title": "奖品名称",
+          "description": "",
+          "type": "string"
+        },
+        "giftPkgDescription": {
+          "title": "奖品描述",
+          "description": "",
+          "type": "string",
+          "ui:hidden": "template!='1' && template!='3'"
+        },
+        "faceValue": {
+          "title": "面额",
+          "description": "",
+          "type": "string",
+          "enum": ["1", "2", "3", "4", "5"],
+          "enumNames": [
+            "固定金额",
+            "固定折扣",
+            "减至",
+            "纯文案",
+            "自定义前中后缀"
+          ]
+        },
+        "fixedAmountBefore": {
+          "title": "",
+          "description": "",
+          "type": "string",
+          "pattern": "^([1-9]\\d*|0)$",
+          "ui:options": { "addonBefore": "满", "addonAfter": "元" },
+          "ui:hidden": "faceValue!='1' || (template!=1 && template!=4)",
+          "ui:width": "42%"
+        },
+        "fixedAmountAfter": {
+          "title": "",
+          "description": "",
+          "type": "string",
+          "pattern": "^([1-9]\\d*)$",
+          "ui:options": { "addonBefore": "减", "addonAfter": "元" },
+          "ui:hidden": "faceValue!='1'",
+          "ui:width": "42%"
+        },
+        "discount": {
+          "title": "",
+          "description": "1-9，支持小数点后一位",
+          "type": "string",
+          "pattern": "^((0\\.[1-9]{1})|(([1-9]{1})(\\.\\d{1})?))$",
+          "ui:options": { "addonAfter": "折" },
+          "ui:hidden": "faceValue!='2'",
+          "ui:width": "50%"
+        },
+        "reduce": {
+          "title": "",
+          "description": "",
+          "type": "string",
+          "pattern": "^([1-9]\\d*)$",
+          "ui:options": { "addonAfter": "元" },
+          "ui:hidden": "faceValue!='3'",
+          "ui:width": "50%"
+        },
+        "faceValuePurePrefixText": {
+          "title": "前缀",
+          "description": "",
+          "type": "string",
+          "ui:hidden": "faceValue!='5'",
+          "ui:width": "50%"
+        },
+        "faceValuePureInfixText": {
+          "title": "中缀",
+          "description": "",
+          "type": "string",
+          "ui:hidden": "{{(!(rootValue.faceValue=='4' && rootValue.template==2)) && (!(rootValue.faceValue=='5'))}}",
+          "ui:width": "50%"
+        },
+        "faceValuePureText": {
+          "title": "{{rootValue.template=='2'?'后缀':rootValue.template=='1'?rootValue.faceValue=='5'?'后缀':'':rootValue.template=='3'?'后缀':''}}",
+          "description": "",
+          "type": "string",
+          "ui:hidden": "faceValue!='4' && faceValue!='5'",
+          "ui:width": "50%"
+        },
+        "effectiveTimeType": {
+          "title": "使用有效期",
+          "description": "",
+          "type": "string",
+          "enum": ["1", "2", "3", "4"],
+          "enumNames": ["固定时间", "自领取之时起", "自领取之日起", "纯文案"],
+          "ui:hidden": "template!=1 && template!=4"
+        },
+        "beginTime": {
+          "title": "开始时间",
+          "description": "",
+          "type": "string",
+          "ui:widget": "date",
+          "ui:hidden": "effectiveTimeType!='1' || (template!=1 && template!=4)",
+          "ui:width": "50%"
+        },
+        "endTime": {
+          "title": "结束时间",
+          "description": "",
+          "type": "string",
+          "ui:widget": "date",
+          "ui:hidden": "effectiveTimeType!='1' || (template!=1 && template!=4)",
+          "ui:width": "50%"
+        },
+        "effectiveMin": {
+          "title": "",
+          "description": "",
+          "type": "string",
+          "pattern": "^[0-9]+$",
+          "ui:options": { "addonAfter": "分钟" },
+          "ui:hidden": "effectiveTimeType!='2' || (template!=1 && template!=4)",
+          "ui:width": "50%"
+        },
+        "effectiveDay": {
+          "title": "",
+          "description": "",
+          "type": "string",
+          "pattern": "^[0-9]+$",
+          "ui:options": { "addonAfter": "天" },
+          "ui:hidden": "effectiveTimeType!='3' || (template!=1 && template!=4)",
+          "ui:width": "50%"
+        },
+        "effectTimePureText": {
+          "title": "",
+          "description": "",
+          "type": "string",
+          "ui:hidden": "effectiveTimeType!='4' || template!=1"
+        },
+        "notAvailableJumpurl": {
+          "title": "不可领引导跳转链接",
+          "description": "",
+          "type": "string",
+          "pattern": "^(https?|ftp|file)://[-a-zA-Z0-9+&@#/%?=~_|!:,.;]*[-a-zA-Z0-9+&@#/%=~_|]",
+          "ui:hidden": "template!=3"
+        },
+        "outOfStockJumpUrl": {
+          "title": "活动无库存引导跳转链接",
+          "description": "",
+          "type": "string",
+          "pattern": "^(https?|ftp|file)://[-a-zA-Z0-9+&@#/%?=~_|!:,.;]*[-a-zA-Z0-9+&@#/%=~_|]",
+          "ui:hidden": "template!=3"
+        },
+        "toUseUrl4Pc": {
+          "title": "奖品去使用链接(PC)",
+          "description": "",
+          "type": "string"
+        },
+        "toUseUrl4Wx": {
+          "title": "奖品去使用链接(无线)",
+          "description": "",
+          "type": "string"
+        },
+        "subscriptText": {
+          "title": "角标文案",
+          "description": "在会场上券模块左上角展示的文案",
+          "type": "string",
+          "maxLength": 6,
+          "ui:options": { "placeholder": "如：F3可领" },
+          "ui:hidden": "template!=2"
+        },
+        "doubleCheckPointText": {
+          "title": "二次确认框文案",
+          "description": "如：你确认花费x里程参与抽奖(兑换)吗？",
+          "type": "string",
+          "maxLength": 20,
+          "ui:options": {
+            "placeholder": "如：你确认花费x里程参与抽奖(兑换)吗？"
+          },
+          "ui:hidden": "@['LOTTERY','EXCHANGE'].indexOf(formData.wfCommonInfo.productCode)===-1 || rootValue.template!=2"
+        },
+        "useRestrictionsText": {
+          "title": "使用限制文案",
+          "description": "如：满3000可用，仅F3会员可用",
+          "type": "string",
+          "maxLength": 1024,
+          "ui:options": { "placeholder": "如：满3000可用，仅F3会员可用" },
+          "ui:hidden": "template!=2 && template!=4"
+        },
+        "wonToastText": {
+          "title": "中奖弹窗按钮文案",
+          "description": "中奖弹窗按钮文案",
+          "type": "string",
+          "maxLength": 20,
+          "default": "知道了",
+          "ui:hidden": "@['LOTTERY'].indexOf(formData.wfCommonInfo.productCode)===-1 || rootValue.template!=2"
+        },
+        "wonToastBtnJumpUrl": {
+          "title": "中奖弹窗按钮跳转地址",
+          "description": "",
+          "type": "string",
+          "ui:hidden": "@['LOTTERY'].indexOf(formData.wfCommonInfo.productCode)===-1 || rootValue.template!=2"
+        },
+        "notWonToastText": {
+          "title": "未中奖弹窗按钮文案",
+          "description": "未中奖弹窗按钮文案",
+          "type": "string",
+          "maxLength": 20,
+          "default": "再抽一次",
+          "ui:hidden": "@['LOTTERY'].indexOf(formData.wfCommonInfo.productCode)===-1 || rootValue.template!=2"
+        },
+        "notWonToastBtnJumpUrl": {
+          "title": "未中奖弹窗按钮跳转地址",
+          "description": "未中奖弹窗按钮跳转地址",
+          "type": "string",
+          "ui:hidden": "@['LOTTERY'].indexOf(formData.wfCommonInfo.productCode)===-1 || rootValue.template!=2"
+        },
+        "couponRingType": {
+          "title": "优惠券圈品方式",
+          "description": "",
+          "type": "string",
+          "enum": ["1"],
+          "enumNames": ["海神id"],
+          "ui:hidden": "template!=4"
+        },
+        "couponRingValue": {
+          "title": "圈品标志",
+          "description": "",
+          "type": "string",
+          "ui:hidden": "template!=4"
+        },
+        "alipayCouponStockActChannels": {
+          "title": "活动渠道",
+          "description": "",
+          "type": "array",
+          "items": { "type": "string" },
+          "enum": ["HOME_PAGE", "NATIONAL_DAY_PROMOTION"],
+          "enumNames": ["首页SVU/SSU", "会场"],
+          "ui:hidden": "template!=4"
+        },
+        "alipayCouponStockBusinessLine": {
+          "title": "业务线",
+          "description": "",
+          "type": "string",
+          "enum": [
+            "通用",
+            "国际机票",
+            "国内机票",
+            "火车票",
+            "汽车票",
+            "用车",
+            "酒店",
+            "度假",
+            "门票"
+          ],
+          "enumNames": [
+            "通用",
+            "国际机票",
+            "国内机票",
+            "火车票",
+            "汽车票",
+            "用车",
+            "酒店",
+            "度假",
+            "门票"
+          ],
+          "ui:hidden": "template!=4"
+        },
+        "alipayCouponStockDeliveryCityCode": {
+          "title": "投放城市（6位行政区划,多个英文逗号分隔）",
+          "description": "全国填 ALL ;6位行政区划,多个英文逗号分隔",
+          "type": "string",
+          "pattern": "^(ALL)?([,]?(\\d){6})*$",
+          "ui:hidden": "template!=4"
+        },
+        "kvConfig": {
+          "title": "自定义素材",
+          "description": "",
+          "type": "array",
+          "items": { "type": "string" },
+          "enum": [""],
+          "ui:widget": "kvList"
+        }
+      },
+      "type": "object",
+      "required": [
+        "template",
+        "giftPkgName",
+        "faceValue",
+        "fixedAmountBefore",
+        "fixedAmountAfter",
+        "discount",
+        "reduce",
+        "faceValuePureText",
+        "effectiveTimeType",
+        "beginTime",
+        "endTime",
+        "effectiveMin",
+        "effectiveDay",
+        "effectTimePureText",
+        "alipayCouponStockBusinessLine"
+      ],
+      "title": "用户端礼包展示信息",
+      "name": "applyGiftPackageShowConfig"
+    },
+    "applyButtonShowConfig": {
+      "properties": {
+        "showAdvancedSetting": {
+          "title": "高级配置",
+          "description": "",
+          "type": "boolean"
+        },
+        "activeNotReachedStartTime": {
+          "title": "未到活动开始时间",
+          "description": "",
+          "type": "string",
+          "default": "未开始",
+          "ui:hidden": "showAdvancedSetting==false"
+        },
+        "activeIsOver": {
+          "title": "活动已结束",
+          "description": "",
+          "type": "string",
+          "default": "已结束",
+          "ui:hidden": "showAdvancedSetting==false"
+        },
+        "notAvailable": {
+          "title": "不可领取",
+          "description": "",
+          "type": "string",
+          "default": "不可领",
+          "ui:hidden": "showAdvancedSetting==false"
+        },
+        "available": {
+          "title": "可参与",
+          "description": "",
+          "type": "string",
+          "default": "立即抢",
+          "ui:hidden": "showAdvancedSetting==false"
+        },
+        "received": {
+          "title": "已领取",
+          "description": "",
+          "type": "string",
+          "default": "已领取",
+          "ui:hidden": "showAdvancedSetting==false"
+        },
+        "outOfStock": {
+          "title": "库存不足（玩法或奖品）",
+          "description": "",
+          "type": "string",
+          "default": "已抢完",
+          "ui:hidden": "showAdvancedSetting==false"
+        },
+        "toUse": {
+          "title": "去使用",
+          "description": "",
+          "type": "string",
+          "default": "去使用",
+          "ui:hidden": "showAdvancedSetting==false"
+        },
+        "notWonAndNotAvailable": {
+          "title": "抽完未中",
+          "description": "",
+          "type": "string",
+          "default": "已抽过",
+          "ui:hidden": "@['LOTTERY'].indexOf(formData.wfCommonInfo.productCode)===-1 || rootValue.showAdvancedSetting!=true"
+        },
+        "userParticipateLimitReached": {
+          "title": "参与次数到上限",
+          "description": "",
+          "type": "string",
+          "default": "不可领",
+          "ui:hidden": "showAdvancedSetting==false"
+        }
+      },
+      "type": "object",
+      "required": [],
+      "title": "用户端按钮展示信息",
+      "name": "applyButtonShowConfig"
+    },
+    "applyPromptConfig": {
+      "properties": {
+        "showAdvancedSetting": {
+          "title": "高级配置",
+          "description": "",
+          "type": "boolean"
+        },
+        "applySuccessMainTitle": {
+          "title": "成功提示(主标题)",
+          "description": "会场领券后的弹框主标题",
+          "type": "string",
+          "max": 6,
+          "default": "恭喜您",
+          "ui:hidden": "showAdvancedSetting==false"
+        },
+        "applyFailedMainTitle": {
+          "title": "失败提示(主标题)",
+          "description": "会场领券后的弹框主标题",
+          "type": "string",
+          "max": 6,
+          "default": "很遗憾",
+          "ui:hidden": "showAdvancedSetting==false"
+        },
+        "applySuccess": {
+          "title": "参与成功",
+          "description": "",
+          "type": "string",
+          "default": "恭喜您！",
+          "ui:hidden": "showAdvancedSetting==false"
+        },
+        "lotteryNotWon": {
+          "title": "未中奖",
+          "description": "",
+          "type": "string",
+          "default": "你和奖品只差一丢丢",
+          "ui:hidden": true
+        },
+        "activeNotReachedStartTime": {
+          "title": "活动未到开始时间",
+          "description": "",
+          "type": "string",
+          "default": "亲，活动尚未开始！",
+          "ui:hidden": "showAdvancedSetting==false"
+        },
+        "activityHasExpired": {
+          "title": "已过活动结束时间",
+          "description": "",
+          "type": "string",
+          "default": "亲，活动已结束！",
+          "ui:hidden": "showAdvancedSetting==false"
+        },
+        "outOfStock": {
+          "title": "库存不足",
+          "description": "",
+          "type": "string",
+          "default": "已被抢光啦，再看看别的好福利吧！",
+          "ui:hidden": "showAdvancedSetting==false"
+        },
+        "userTotalParticipateLimitReached": {
+          "title": "单用户总参与次数到达上限",
+          "description": "",
+          "type": "string",
+          "default": "参与次数已达上限",
+          "ui:hidden": "showAdvancedSetting==false"
+        },
+        "userDailyParticipateLimitReached": {
+          "title": "单用户每天参与次数到达上限",
+          "description": "",
+          "type": "string",
+          "default": "今日参与次数已达上限，明天再来试试～",
+          "ui:hidden": "showAdvancedSetting==false"
+        },
+        "userWeeklyParticipateLimitReached": {
+          "title": "单用户每周参与次数到达上限",
+          "description": "",
+          "type": "string",
+          "default": "本周参与次数已达上限，下周再来试试～",
+          "ui:hidden": "showAdvancedSetting==false"
+        },
+        "userTotalLotteryWonLimitReached": {
+          "title": "单用户总中奖次数到达上限",
+          "description": "",
+          "type": "string",
+          "default": "中奖次数已达上限",
+          "ui:hidden": true
+        },
+        "userDailyLotteryWonLimitReached": {
+          "title": "单用户每天总中奖次数到达上限",
+          "description": "",
+          "type": "string",
+          "default": "今日中奖次数已达上限，明天再来试试～",
+          "ui:hidden": true
+        },
+        "userWeeklyLotteryWonLimitReached": {
+          "title": "单用户每周总中奖次数到达上限",
+          "description": "",
+          "type": "string",
+          "default": "本周中奖次数已达上限，下周再来试试～",
+          "ui:hidden": true
+        },
+        "userGroupLotteryWonLimitReached": {
+          "title": "单用户奖品组中奖次数到达上限",
+          "description": "",
+          "type": "string",
+          "default": "本活动中奖次数已达上限",
+          "ui:hidden": "showAdvancedSetting==false"
+        },
+        "securityBlock": {
+          "title": "安全码等身份验证不通过",
+          "description": "",
+          "type": "string",
+          "default": "你和奖品只差一丢丢",
+          "ui:hidden": "showAdvancedSetting==false"
+        },
+        "participationConditionsNotReached": {
+          "title": "触发参与条件不满足",
+          "description": "",
+          "type": "string",
+          "default": "你和奖品只差一丢丢",
+          "ui:hidden": "showAdvancedSetting==false"
+        },
+        "deductPropertyLacking": {
+          "title": "扣减资源不足",
+          "description": "{扣减资源名称}会自动替换为上面选择的资源类型请勿随意更改",
+          "type": "string",
+          "default": "您的{扣减资源名称}不足，无法参与活动",
+          "ui:hidden": true
+        },
+        "bottomPrompt": {
+          "title": "其他原因发奖失败",
+          "description": "",
+          "type": "string",
+          "default": "你和奖品只差一丢丢",
+          "ui:hidden": "showAdvancedSetting==false"
+        }
+      },
+      "type": "object",
+      "required": [],
+      "title": "用户端提示文案",
+      "name": "applyPromptConfig"
+    },
+    "generalExt": {
+      "properties": {
+        "kvConfig": {
+          "title": "扩展key-value",
+          "description": "",
+          "type": "array",
+          "items": { "type": "string" },
+          "enum": [""],
+          "ui:widget": "kvList"
+        }
+      },
+      "type": "object",
+      "required": [],
+      "title": "扩展信息",
+      "name": "generalExt"
+    },
+    "wfCommonInfo": {
+      "name": "wfCommonInfo",
+      "type": "object",
+      "properties": {
+        "productCode": {},
+        "bizCode": {},
+        "theTwoEditors": {},
+        "subActStatus": {}
+      }
+    }
+  },
+  "type": "object"
+}

--- a/packages/FR1.0/src/components/ArrowDown.jsx
+++ b/packages/FR1.0/src/components/ArrowDown.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+export default function ArrowDown({ height, width, onClick }) {
+  return (
+    <svg
+      className="fr-arrow-icon"
+      viewBox="0 0 1024 1024"
+      width={width || height || 256}
+      height={height || width || 256}
+      onClick={onClick}
+    >
+      <path
+        d="M755.2 648.362667a42.666667 42.666667 0 0 1 0.554667 60.330666l-213.333334 217.173334a42.666667 42.666667 0 0 1-60.842666 0l-213.333334-217.173334a42.666667 42.666667 0 0 1 60.842667-59.818666L469.333333 791.68V128a42.666667 42.666667 0 1 1 85.333334 0v663.68l140.245333-142.805333a42.666667 42.666667 0 0 1 60.330667-0.512z"
+        fill="#1890ff"
+      ></path>
+    </svg>
+  );
+}

--- a/packages/FR1.0/src/components/ArrowUp.jsx
+++ b/packages/FR1.0/src/components/ArrowUp.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+export default function ArrowUp({ height, width, onClick }) {
+  return (
+    <svg
+      className="fr-arrow-icon"
+      viewBox="0 0 1024 1024"
+      width={width || height || 256}
+      height={height || width || 256}
+      onClick={onClick}
+    >
+      <path
+        d="M755.2 375.637333a42.666667 42.666667 0 0 0 0.554667-60.330666l-213.333334-217.173334a42.666667 42.666667 0 0 0-60.842666 0l-213.333334 217.173334a42.666667 42.666667 0 1 0 60.842667 59.818666L469.333333 232.32V896a42.666667 42.666667 0 1 0 85.333334 0V232.32l140.245333 142.805333a42.666667 42.666667 0 0 0 60.330667 0.512z"
+        fill="#1890ff"
+      ></path>
+    </svg>
+  );
+}

--- a/packages/FR1.0/src/components/dateHoc.jsx
+++ b/packages/FR1.0/src/components/dateHoc.jsx
@@ -1,0 +1,54 @@
+/**
+ * Created by Tw93 on 2019-12-07.
+ * 抽离高阶日期组件
+ */
+
+import React from 'react';
+import moment from 'moment';
+import { getFormat } from '../utils';
+
+export default (p, onChange, DateComponent) => {
+  const style = p.invalid
+    ? { borderColor: '#ff4d4f', boxShadow: '0 0 0 2px rgba(255,77,79,.2)' }
+    : {};
+  let { format = 'dateTime' } = p.schema;
+  if (p.options && p.options.format) {
+    format = p.options.format;
+  }
+  const dateFormat = getFormat(format);
+  // week的时候会返回 2020-31周 quarter会返回 2020-Q2 需要处理之后才能被 moment
+  let _value = p.value || '';
+  if (typeof _value === 'string') {
+    if (format === 'week') {
+      _value = _value.substring(0, _value.length - 1);
+    }
+    if (format === 'quarter') {
+      _value = _value.replace('Q', '');
+    }
+  }
+  if (_value) {
+    _value = moment(_value, dateFormat);
+  }
+
+  const placeholderObj = p.description ? { placeholder: p.description } : {};
+
+  const dateParams = {
+    ...placeholderObj,
+    ...p.options,
+    value: _value,
+    style: { width: '100%', ...style },
+    disabled: p.disabled || p.readOnly,
+    onChange,
+  };
+
+  // TODO: format是在options里自定义的情况，是否要判断一下要不要showTime
+  if (format === 'dateTime') {
+    dateParams.showTime = true;
+  }
+
+  if (['week', 'month', 'quarter', 'year'].indexOf(format) > -1) {
+    dateParams.picker = format;
+  }
+
+  return <DateComponent {...dateParams} />;
+};

--- a/packages/FR1.0/src/components/foldIcon.jsx
+++ b/packages/FR1.0/src/components/foldIcon.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+const FoldIcon = ({
+  fold = false,
+  width,
+  height,
+  fill,
+  style = {},
+  className,
+  ...rest
+}) => (
+  <div
+    style={style}
+    className={
+      fold
+        ? `fold-icon ${className}`
+        : `fold-icon fold-icon-active ${className}`
+    }
+    {...rest}
+  >
+    <svg viewBox="0 0 1024 1024" width={width || 18} height={height || 18}>
+      <path
+        d="M942.048 306.176c-12.288-12.288-31.328-13.024-43.008-2.016L529.056 674.112c-15.072 15.872-19.008 15.808-34.816 0L124.288 304.16c-11.68-11.04-30.72-10.272-43.008 2.016-12.512 12.512-13.216 32.032-1.6 43.68L490.624 760.8c5.056 5.056 11.648 7.328 18.464 7.744h5.152c6.816-.448 13.408-2.72 18.464-7.744l410.944-410.944c11.584-11.648 10.88-31.2-1.6-43.68z"
+        fill={fill || '#3c3c3c'}
+      />
+    </svg>
+  </div>
+);
+
+export default FoldIcon;

--- a/packages/FR1.0/src/components/html.jsx
+++ b/packages/FR1.0/src/components/html.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export default function html({ value, schema, ...rest }) {
+  let __html = '';
+  try {
+    __html = value ? value : schema.default;
+    if (typeof __html !== 'string') {
+      __html = '';
+    }
+  } catch (error) {}
+  return <div dangerouslySetInnerHTML={{ __html }} />;
+}

--- a/packages/FR1.0/src/components/map.jsx
+++ b/packages/FR1.0/src/components/map.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+
+export default function map(p) {
+  let className = 'fr-map ';
+  const { options = {} } = p || {};
+  const isModal = options.modal || options.drawer;
+  className += isModal ? 'fr-wrapper' : ''; // 因为modal跳出fr的dom层级了，需要重新加个顶层的className
+  const _value = p.value || {};
+  return (
+    <div className={className}>
+      {Object.keys(_value).map(name => {
+        return p.getSubField({
+          name,
+          value: p.value[name],
+          onChange(key, val, objValue) {
+            let value = {
+              ...p.value,
+              [key]: val,
+            };
+            // 第三个参数，允许object里的一个子控件改动整个object的值
+            if (objValue) {
+              value = objValue;
+            }
+            if (p.useLogger) {
+              console.group(p.name);
+              console.log(
+                `%c${key}:`,
+                'color: #47B04B; font-weight: 700;',
+                val
+              );
+              console.log(
+                `%c${p.name}:`,
+                'color: #00A7F7; font-weight: 700;',
+                value
+              );
+              console.groupEnd();
+            }
+            p.onChange(p.name, value);
+          },
+          rootValue: p.value,
+        });
+      })}
+    </div>
+  );
+}

--- a/packages/FR1.0/src/components/multiSelectHoc.jsx
+++ b/packages/FR1.0/src/components/multiSelectHoc.jsx
@@ -1,0 +1,41 @@
+/**
+ * Created by Tw93 on 2019-12-07.
+ * 抽离高阶多选组件
+ */
+
+import React from 'react';
+import { getArray } from '../utils';
+
+export default MultiComponent => p => {
+  const { Option } = MultiComponent;
+  const onChange = value => p.onChange(value);
+  const style = p.invalid
+    ? { borderColor: '#ff4d4f', boxShadow: '0 0 0 2px rgba(255,77,79,.2)' }
+    : {};
+  const schema = p.schema || {};
+  const { items = {} } = schema;
+  const { enum: enums, enumNames } = items && items.enum ? items : schema;
+  const _value = p.value && Array.isArray(p.value) ? p.value : [];
+  return (
+    <MultiComponent
+      {...p.options}
+      style={{ width: '100%', ...style }}
+      mode="multiple"
+      disabled={p.disabled || p.readOnly}
+      value={_value}
+      onChange={onChange}
+    >
+      {getArray(enums).map((val, index) => (
+        <Option value={val} key={index}>
+          <span
+            // eslint-disable-next-line react/no-danger
+            dangerouslySetInnerHTML={{
+              __html:
+                enumNames && Array.isArray(enumNames) ? enumNames[index] : val,
+            }}
+          />
+        </Option>
+      ))}
+    </MultiComponent>
+  );
+};

--- a/packages/FR1.0/src/components/numberHoc.jsx
+++ b/packages/FR1.0/src/components/numberHoc.jsx
@@ -1,0 +1,40 @@
+/**
+ * Created by Tw93 on 2019-12-07.
+ * 抽离数字输入组件
+ */
+
+import React from 'react';
+
+export default NumberComponent => p => {
+  const style = p.invalid
+    ? { borderColor: '#ff4d4f', boxShadow: '0 0 0 2px rgba(255,77,79,.2)' }
+    : {};
+  const { max, min, step } = p.schema;
+  let obj = {};
+  if (max || max === 0) {
+    obj = { max };
+  }
+
+  if (min || min === 0) {
+    obj = { ...obj, min };
+  }
+
+  if (step) {
+    obj = { ...obj, step };
+  }
+
+  const onChange = value => {
+    p.onChange(value);
+  };
+
+  return (
+    <NumberComponent
+      {...obj}
+      style={{ width: '100%', ...style }}
+      disabled={p.disabled || p.readOnly}
+      {...p.options}
+      value={p.value}
+      onChange={onChange}
+    />
+  );
+};

--- a/packages/FR1.0/src/components/previewContent.jsx
+++ b/packages/FR1.0/src/components/previewContent.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+const defaultImg =
+  'https://img.alicdn.com/tfs/TB14tSiKhTpK1RjSZFKXXa2wXXa-354-330.png';
+
+export default (format, value) => {
+  return format === 'image' ? (
+    <img
+      src={value || defaultImg}
+      alt="图片地址错误"
+      className="fr-preview-image"
+    />
+  ) : null;
+};

--- a/packages/FR1.0/src/components/radioHoc.jsx
+++ b/packages/FR1.0/src/components/radioHoc.jsx
@@ -1,0 +1,32 @@
+/**
+ * Created by Tw93 on 2019-12-07.
+ * 单选输入组件
+ */
+
+import React from 'react';
+import { getArray } from '../utils';
+
+export default p => {
+  const Radio = p.Radio;
+  const RadioGroup = Radio.Group;
+  const { enum: enums, enumNames } = p.schema || {};
+  return (
+    <RadioGroup
+      disabled={p.disabled || p.readOnly}
+      value={p.value}
+      onChange={p.onChange}
+    >
+      {getArray(enums).map((val, index) => (
+        <Radio value={val} key={index}>
+          <span
+            // eslint-disable-next-line react/no-danger
+            dangerouslySetInnerHTML={{
+              __html:
+                enumNames && Array.isArray(enumNames) ? enumNames[index] : val,
+            }}
+          />
+        </Radio>
+      ))}
+    </RadioGroup>
+  );
+};

--- a/packages/FR1.0/src/components/rangeHoc.jsx
+++ b/packages/FR1.0/src/components/rangeHoc.jsx
@@ -1,0 +1,55 @@
+/**
+ * Created by Tw93 on 2019-12-07.
+ * 抽离高阶日期组件
+ */
+
+import React from 'react';
+import moment from 'moment';
+import { getFormat } from '../utils';
+
+export default ({
+  onChange,
+  RangeComponent,
+  value,
+  schema = {},
+  options,
+  disabled,
+  readOnly,
+}) => {
+  let { format = 'dateTime' } = schema;
+  if (options && options.format) {
+    format = options.format;
+  }
+  const dateFormat = getFormat(format);
+  let [start, end] = Array.isArray(value) ? value : [];
+
+  // week的时候会返回 2020-31周 quarter会返回 2020-Q2 需要处理之后才能被 moment
+  if (typeof start === 'string' && typeof end === 'string') {
+    if (format === 'week') {
+      start = start.substring(0, start.length - 1);
+      end = end.substring(0, end.length - 1);
+    }
+    if (format === 'quarter') {
+      start = start.replace('Q', '');
+      end = end.replace('Q', '');
+    }
+  }
+
+  const _value =
+    start && end ? [moment(start, dateFormat), moment(end, dateFormat)] : [];
+
+  const dateParams = {
+    ...options,
+    value: _value,
+    style: { width: '100%' },
+    showTime: format === 'dateTime',
+    disabled: disabled || readOnly,
+    onChange,
+  };
+
+  if (['week', 'month', 'quarter', 'year'].indexOf(format) > -1) {
+    dateParams.picker = format;
+  }
+
+  return <RangeComponent {...dateParams} />;
+};

--- a/packages/FR1.0/src/components/selectHoc.jsx
+++ b/packages/FR1.0/src/components/selectHoc.jsx
@@ -1,0 +1,39 @@
+/**
+ * Created by Tw93 on 2019-12-07.
+ * 高阶选择组件
+ */
+
+import React from 'react';
+import { getArray } from '../utils';
+
+export default SelectComponent => p => {
+  const { Option } = SelectComponent;
+  const onChange = value => p.onChange(value);
+  const style = p.invalid
+    ? { borderColor: '#ff4d4f', boxShadow: '0 0 0 2px rgba(255,77,79,.2)' }
+    : {};
+  const { enum: enums, enumNames } = p.schema || {};
+  return (
+    <SelectComponent
+      style={{ width: '100%', ...style }}
+      {...p.options}
+      disabled={p.disabled || p.readOnly}
+      value={p.value}
+      onChange={onChange}
+    >
+      {getArray(enums).map((val, index) => {
+        let option =
+          enumNames && Array.isArray(enumNames) ? enumNames[index] : val;
+        const isHtml = typeof option === 'string' && option[0] === '<';
+        if (isHtml) {
+          option = <span dangerouslySetInnerHTML={{ __html: option }} />;
+        }
+        return (
+          <Option value={val} key={index}>
+            {option}
+          </Option>
+        );
+      })}
+    </SelectComponent>
+  );
+};

--- a/packages/FR1.0/src/components/sliderHoc.jsx
+++ b/packages/FR1.0/src/components/sliderHoc.jsx
@@ -1,0 +1,55 @@
+/**
+ * Created by Tw93 on 2019-12-07.
+ * 滑动输入组件
+ */
+
+import React from 'react';
+
+export default (SliderComponent, NumberComponent) => p => {
+  const style = p.invalid
+    ? { borderColor: '#ff4d4f', boxShadow: '0 0 0 2px rgba(255,77,79,.2)' }
+    : {};
+  const { max, min, step } = p.schema;
+  let setting = {};
+  if (max || max === 0) {
+    setting = { max };
+  }
+
+  if (min || min === 0) {
+    setting = { ...setting, min };
+  }
+
+  if (step) {
+    setting = { ...setting, step };
+  }
+
+  const onChange = value => {
+    p.onChange(p.name, value);
+  };
+
+  return (
+    <div className="fr-slider">
+      <SliderComponent
+        style={{ flexGrow: 1, marginRight: 12 }}
+        {...setting}
+        onChange={onChange}
+        value={typeof p.value === 'number' ? p.value : min || 0}
+        disabled={p.disabled || p.readOnly}
+      />
+      {p.readOnly ? (
+        <span style={{ width: '90px' }}>
+          {p.value === (undefined || '') ? '-' : p.value}
+        </span>
+      ) : (
+        <NumberComponent
+          {...p.options}
+          {...setting}
+          style={{ width: '90px', ...style }}
+          value={p.value}
+          disabled={p.disabled}
+          onChange={onChange}
+        />
+      )}
+    </div>
+  );
+};

--- a/packages/FR1.0/src/const.js
+++ b/packages/FR1.0/src/const.js
@@ -1,0 +1,49 @@
+const typeTemplate = "'${title}' is not a valid ${type}";
+
+export const defaultValidateMessages = {
+  default: "Validation error on field '${title}'",
+  required: "'${title}' is required",
+  enum: "'${title}' must be one of [${enum}]",
+  whitespace: "'${title}' cannot be empty",
+  date: {
+    format: "'${title}' is invalid for format date",
+    parse: "'${title}' could not be parsed as date",
+    invalid: "'${title}' is invalid date",
+  },
+  types: {
+    string: typeTemplate,
+    method: typeTemplate,
+    array: typeTemplate,
+    object: typeTemplate,
+    number: typeTemplate,
+    date: typeTemplate,
+    boolean: typeTemplate,
+    integer: typeTemplate,
+    float: typeTemplate,
+    regexp: typeTemplate,
+    email: typeTemplate,
+    url: typeTemplate,
+    hex: typeTemplate,
+  },
+  string: {
+    len: "'${title}' must be exactly ${len} characters",
+    min: "'${title}' must be at least ${min} characters",
+    max: "'${title}' cannot be longer than ${max} characters",
+    range: "'${title}' must be between ${min} and ${max} characters",
+  },
+  number: {
+    len: "'${title}' must equal ${len}",
+    min: "'${title}' cannot be less than ${min}",
+    max: "'${title}' cannot be greater than ${max}",
+    range: "'${title}' must be between ${min} and ${max}",
+  },
+  array: {
+    len: "'${title}' must be exactly ${len} in length",
+    min: "'${title}' cannot be less than ${min} in length",
+    max: "'${title}' cannot be greater than ${max} in length",
+    range: "'${title}' must be between ${min} and ${max} in length",
+  },
+  pattern: {
+    mismatch: "'${title}' does not match pattern ${pattern}",
+  },
+};

--- a/packages/FR1.0/src/hooks.js
+++ b/packages/FR1.0/src/hooks.js
@@ -1,0 +1,145 @@
+import {
+  useReducer,
+  useContext,
+  useRef,
+  useEffect,
+  useState,
+  createContext,
+} from 'react';
+
+export const Ctx = createContext(() => {});
+export const StoreCtx = createContext({});
+
+// 使用最顶层组件的 setState
+export const useGlobal = () => {
+  return useContext(Ctx);
+};
+
+// 组件最顶层传入的所有props
+export const useStore = () => {
+  return useContext(StoreCtx);
+};
+
+// export default logger;
+
+// 类似于class component 的 setState
+export const useSet = initState => {
+  let show = useRef(true);
+  const [state, setState] = useReducer((state, newState) => {
+    let action = newState;
+    if (typeof newState === 'function') {
+      action = action(state);
+    }
+    if (newState.action && newState.payload) {
+      action = newState.payload;
+      if (typeof action === 'function') {
+        action = action(state);
+      }
+    }
+    const result = { ...state, ...action };
+    // if (newState.action !== 'no-log') {
+    // 解决会展示两遍的问题，TODO: 是否真的解决了？如果有不是每次重复显示两遍的咋办？
+    if (show.current === true) {
+      // console.group(newState.action || 'action'); // TODO: give it a name
+      // console.log('%cState:', 'color: #9E9E9E; font-weight: 700;', state);
+      // console.log('%cAction:', 'color: #00A7F7; font-weight: 700;', action);
+      // console.log('%cNext:', 'color: #47B04B; font-weight: 700;', result);
+      // console.groupEnd();
+      show.current = false;
+    } else {
+      show.current = true;
+    }
+
+    // } else {
+    // }
+    return result;
+  }, initState);
+  return [state, setState];
+};
+
+// start: true 开始、false 暂停
+export function useInterval(callback, delay, start) {
+  const savedCallback = useRef();
+  // Remember the latest callback.
+  useEffect(() => {
+    savedCallback.current = callback;
+  }, [callback]);
+
+  // Set up the interval.
+  const id = useRef();
+  useEffect(() => {
+    if (!start) {
+      return;
+    }
+    function tick() {
+      savedCallback && savedCallback.current && savedCallback.current();
+    }
+    tick();
+    if (delay !== null) {
+      id.current = setInterval(tick, delay);
+      return () => clearInterval(id.current);
+    }
+  }, [delay, start]);
+  return () => clearInterval(id.current);
+}
+
+export function usePrevious(value) {
+  // The ref object is a generic container whose current property is mutable ...
+  // ... and can hold any value, similar to an instance property on a class
+  const ref = useRef();
+
+  // Store current value in ref
+  useEffect(() => {
+    ref.current = value;
+  }, [value]); // Only re-run if value changes
+
+  // Return previous value (happens before update in useEffect above)
+  return ref.current;
+}
+
+export const useShowOnce = localKey => {
+  // 从 localStorage 读取 key 值
+  const [show, setShow] = useState(false);
+  let localStr;
+  try {
+    localStr = localStorage.getItem(localKey);
+  } catch (error) {}
+  if (!localStr) {
+    setShow(true);
+    localStorage.setItem(localKey, JSON.stringify(true));
+  }
+  return show;
+};
+
+export const useModal = () => {
+  const [show, setShow] = useState(false);
+  const toggle = () => setShow(!show);
+  return [show, toggle];
+};
+
+export const useWindowState = initState => {
+  const [state, setState] = useState(initState);
+  return [state, setState];
+};
+
+export const useStorageState = (initState = {}, searchKey = 'SAVES') => {
+  // 从 localStorage 读取 search 值
+  const readSearchFromStorage = () => {
+    const searchStr = localStorage.getItem(searchKey);
+    if (searchStr) {
+      try {
+        return JSON.parse(searchStr);
+      } catch (error) {
+        return initState;
+      }
+    }
+    return initState;
+  };
+  const [data, setData] = useState(readSearchFromStorage());
+  // 存储搜索值到 localStorage
+  const setSearchWithStorage = search => {
+    setData(search);
+    localStorage.setItem(searchKey, JSON.stringify(search));
+  };
+  return [data, setSearchWithStorage];
+};

--- a/packages/FR1.0/src/index.css
+++ b/packages/FR1.0/src/index.css
@@ -1,0 +1,345 @@
+/*
+  用于原有样式的覆盖
+ */
+
+.fr-field {
+  font-size: 14px;
+  padding: 0;
+  color: rgba(0, 0, 0, 0.85);
+  line-height: 1.5715;
+  /* font-variant: tabular-nums; */
+}
+
+.fr-field-column {
+  flex-direction: column;
+}
+
+.fr-field-object {
+  flex-direction: column;
+}
+
+.fr-collapse-object {
+  margin-bottom: -1px;
+  overflow: hidden;
+  background: #f7f7f7;
+  border: 0px;
+  border-radius: 2px;
+}
+
+.fr-collapse-object .ant-collapse-header {
+  padding-bottom: 8px !important;
+}
+
+.fr-label {
+  height: 32px;
+  align-items: center;
+}
+
+.fr-label-column {
+  display: flex;
+  /* text-align: left; */
+}
+
+.fr-label-row {
+  display: inline-flex;
+  text-align: right;
+  flex-shrink: 0;
+}
+
+.fr-label-title {
+  display: inline-flex;
+  font-size: 14px;
+  min-height: 22px; /* ""的标签页占位 */
+  line-height: 22px;
+}
+
+.fr-label-list .fr-label-title {
+  font-size: 16px;
+  color: #222;
+  margin: 0 0 12px;
+}
+
+.fr-label-object .fr-label-title {
+  font-size: 16px;
+  color: #222;
+}
+
+.fr-label-object.fr-label {
+  height: auto;
+}
+
+.fr-label-required {
+  margin: 1px 4px 0 0;
+  color: #f5222d;
+  font-size: 14px;
+  font-family: SimSun, sans-serif;
+}
+
+.fr-label-title::after {
+  content: ':';
+  position: relative;
+  top: -0.5px;
+  margin: 0 10px 0 2px;
+}
+
+.fr-label-title.no-colon::after {
+  content: '';
+  margin: 0;
+}
+
+.fr-content {
+}
+
+.fr-content-row {
+  flex: 1;
+  position: relative;
+}
+
+.fr-content-column {
+}
+
+.fr-desc {
+  /* margin-top: 3px; */
+  font-size: 12px;
+  word-break: break-all;
+  color: #888;
+}
+
+.fr-validate {
+  margin-left: 12px;
+  font-size: 12px;
+  word-break: break-all;
+  color: #f5222d;
+}
+
+/* Row */
+
+.fr-validate-row {
+  margin: 3px 0 0 0;
+}
+
+.fr-field-row .fr-tooltip-icon {
+  margin: 3px 2px 0 0;
+}
+
+/* 自定义类 */
+.hover-b--black-20:hover {
+  border-color: rgba(0, 0, 0, 0.3);
+}
+
+.pt44 {
+  padding-top: 46px;
+}
+
+.pv12 {
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+
+.fr-move-icon {
+  position: absolute;
+  top: 0;
+  right: 0;
+  padding-top: 2px;
+  padding-right: 10px;
+  font-size: 24px;
+  font-weight: 300;
+}
+
+.fr-move-icon:hover {
+  cursor: move;
+}
+
+/* 组件内部样式*/
+
+.fr-color-picker {
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  color: #666;
+}
+
+.fr-color-picker .rc-color-picker-trigger {
+  margin-right: 12px;
+  height: 30px;
+  width: 60px;
+  border: 1px solid #e5e5e5;
+}
+
+.fr-color-picker > p {
+  margin: 0;
+  font-size: 14px;
+  line-height: 28px;
+}
+
+.fr-color-picker .rc-color-picker-wrap {
+  display: flex;
+}
+
+.next-input,
+.next-number-picker {
+  width: 100%;
+}
+
+.upload-img {
+  max-width: 200px;
+  max-height: 200px;
+  margin-right: 24px;
+}
+
+.fr-preview-image {
+  width: 160px;
+}
+
+.fr-preview {
+  position: relative;
+  cursor: pointer;
+}
+
+.fr-upload-mod,
+.fr-upload-file {
+  display: flex;
+}
+.fr-upload-mod {
+  align-items: center;
+}
+.fr-upload-mod .fr-upload-preview {
+  margin: 0 12px;
+}
+.fr-upload-file .ant-upload-list-item {
+  margin: 5px 0 0 8px;
+}
+.fr-upload-file .ant-upload-list-item-name {
+  margin-right: 6px;
+}
+.fr-upload-file .ant-upload-list-item-info {
+  cursor: pointer;
+}
+.fr-upload-file .next-upload-list-text .next-upload-list-item-done,
+.fr-upload-file .next-upload-list-text .next-upload-list-item .next-icon {
+  height: 28px;
+  line-height: 28px;
+  margin-left: 12px;
+}
+
+.fr-upload-file .next-upload-list-item-name-wrap {
+  margin-top: -4px;
+}
+
+.fr-sort-help-class {
+  background: #fff;
+}
+
+/* 其他样式 */
+
+.fold-icon.fold-icon-active {
+  transform: rotate(0deg);
+}
+
+.fold-icon {
+  transform: rotate(-90deg);
+  transition: transform 0.24s;
+  cursor: pointer;
+  position: relative;
+}
+
+.fold-icon::after {
+  content: '';
+  position: absolute;
+  top: -20px;
+  right: -10px;
+  bottom: -5px;
+  left: -20px;
+}
+
+.fr-tooltip-toggle {
+  cursor: pointer;
+  position: relative;
+}
+
+.fr-tooltip-toggle:hover .fr-tooltip-container {
+  opacity: 1;
+  visibility: visible;
+}
+
+.fr-tooltip-icon {
+  height: 14px;
+  width: 14px;
+  background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAEnUlEQVR42u1bS0iUURT+zd4Y9KDosSihNhYUaBE9YKpFDKKOOmOLahtJ2SoxA2fUdUoQJK5qU0ib6LlxUYJpkY0LE3tQZkU7y7A0e1jnA4Of8pz//5373/+BF44Oc+/c853v3nOf5xpup0QiMZ9kD8mxeDzeTHKXPveSvKXP3+j/GP1/h++QhzIoW1ZWthu/NYKYysvLN5EhKZJ7ZMQEye8ZyjjJfZIk6vS10YWFhcvI4FoC2wfwLkkf6aiBLt8YHovFNhCoFnRlgNQkY9BJbrLeS9uzqFueYAzXJV9ITgKLVsvBPCnuAAifSIe23kBd7zApHHUI8D3JBfptFUlialbYSJIDweep7+Iog7L4jUMdn4HNzeksmxRcdgColyRZWlq6NQOd21AH6rKrFxiBVanxxcXFS6jSdpsAHtLYUODC1FqAum0S0Q7Mqlp+ESlO2zD8DUmJBhcsgS4bJDwBdhUKb1ko+kll6qLR6AJDU4IuuAZ0W2C7kWnrJy1a/QONvjsNjxLp32VjsEzO1OcOkoJJoeJuGuBWGB4nYCCcD4RGmiSJOm35PIup7kokEplr+CQBCzAJeEeJqC22V3jE2IBQWVd+fv48w2cJmAhbp4C7H7bZaf1KoZJBbET8vCEDRgF/pdXGZim1/ifGl344WtTIJJ//B+ggts+K6t4BrAwBH2GjNKo2CuxVqzJeGLDqFemoFnQ0sq0vDHyP4D+KwI1ILqZqpyqsGmFjznStX8tNIzQlbjYUJasVnCo9wAzsjE1npyPgFQPqJvKDRYC8ioWt/200BFD7FRMwIu0nFBNwgNMFm80Fz0mAFIOqVz4IyoS/ZvQ1mQv1MYBqkO8GCSDXTDRjvAoCznAHrH/X0qu4FqE99Voj2AkErOPsg+3w/wqmwDMjHAkkPGdsPITMBqb7t4SFANjCjTkgoI0ZJY+Hwnp5f9MGdtIMOxF35n1ZXDrG38fYmDa48zWcs4eFANxesUtv+jPMZC4PCwE4NWL0DRvcehkHjyEhACdGCxl9vwBwggEyxw0wXhCAOANG34TsAi4k37kA/RliMnND1ANyGX1DGAMe89Og+uSjaRDSAwKucgeIYSEAcQzc8T4ISDGZrSFygVaml6dAQILJfBEiAl4yy/0KZK6WtsMBJwD+v0bcDk/tlp4yveB0cAmQj8hhs7lQE1NoIAQEPGdsazZ3k+3SoahOAvQfisoDBeR2QAmArjvcsbi2i5FMQ+Ay0Jvn6GIE10VWV2MBIiALmKWrMfFylJsRgkIAsAp1NojX47hCZn74HdfjficAAzp3PY6rf9g4GyBhw3/6Axoi0yW48IDtcQwBRVIUOHaQfguSAiYpvB42Od1Cxiz8s5tkpdfGAwOwSFhhy0xXUnV+DpSEbmCwwFiXKcPXbYTKpnSHykIndFsYf01JsDRJTxCDpUGU7nB5SKcfwuWLiooWK38wQXLJwcOFtIoHE/Bh5v6SE2DMdvNN4BE3nszQ93szfTJDclTbU7lAP5pSGIxY5eWzOdL/lXrkKW6Fp7M3XPTi4SR0zz6dnX087fOEq2k8hTc/nydJm57Pj3v5fP4PSqRR6oYkTaUAAAAASUVORK5CYII=');
+  background-size: cover;
+  display: block;
+  margin: 4px 0 0 4px;
+}
+
+.fr-tooltip-container {
+  position: absolute;
+  width: 160px;
+  left: 50%;
+  white-space: initial !important;
+  bottom: 30px;
+  text-align: center;
+  background: #2b222a;
+  padding: 4px;
+  margin-left: -77px;
+  border-radius: 4px;
+  color: #efefef;
+  font-size: 13px;
+  cursor: auto;
+  z-index: 99999;
+  transition: all 0.5s ease;
+  opacity: 0;
+  visibility: hidden;
+  word-wrap: break-word;
+}
+
+.fr-tooltip-triangle {
+  position: absolute;
+  left: 50%;
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  border-top: 5px solid #2b222a;
+  transition: all 0.5s ease;
+  content: ' ';
+  font-size: 0;
+  line-height: 0;
+  margin-left: -5px;
+  width: 0;
+  bottom: -5px;
+}
+
+.fr-tooltip-toggle::before,
+.fr-tooltip-toggle::after {
+  color: #efefef;
+  font-size: 13px;
+  opacity: 0;
+  pointer-events: none;
+  text-align: center;
+}
+
+.fr-tooltip-toggle:focus::before,
+.fr-tooltip-toggle:focus::after,
+.fr-tooltip-toggle:hover::before,
+.fr-tooltip-toggle:hover::after {
+  opacity: 1;
+  transition: all 0.75s ease;
+}
+
+.fr-slider {
+  display: flex;
+  width: 100%;
+  align-items: center;
+}
+
+.fr-map {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.fr-arrow-icon {
+  cursor: pointer;
+}
+
+.fr-row-error {
+  background-color: rgba(255, 77, 79, 0.2);
+}

--- a/packages/FR1.0/src/index.js
+++ b/packages/FR1.0/src/index.js
@@ -1,0 +1,101 @@
+import React, { useState } from 'react';
+import ReactDOM from 'react-dom';
+import './index.css';
+import 'antd/dist/antd.css';
+import FormRender, { useForm, createWidget } from './App';
+import schema from './basic.json';
+import Percent from './otherWidgets/Percent';
+// import schema1 from './basic1.json';
+
+// console.log(JSON.stringify(combineSchema(schema1.schema, schema1.uiSchema)));
+
+const delay = ms => new Promise(res => setTimeout(res, ms));
+
+// const Demo = () => {
+//   const form = useForm()
+//   return <App form={form} schema={schema} />;
+// };
+
+const PercentWidget = createWidget(({ value, onChange }) => ({
+  onPress: onChange,
+  percent: value,
+}))(Percent);
+
+const Demo = () => {
+  const [display, setDisplay] = useState({}); // TODO: 只是开发时候用
+
+  const form = useForm();
+
+  const onFinish = ({ formData, errorFields }) => {
+    console.log(formData, 'formData', errorFields, 'errors');
+    setDisplay([formData, errorFields]);
+  };
+
+  const outsideValidation = () => {
+    form.setErrorFields({ name: 'percentage', error: ['外部校验错误'] });
+  };
+
+  const beforeFinish = () => {
+    return delay(0).then(_ =>
+      form.setErrorFields({ name: 'percentage', error: ['外部校验错误'] })
+    );
+  };
+
+  // const watch = {
+  //   'a.b.c': value => {
+  //     form.onItemChange('a.b.d', value);
+  //   },
+  //   percentage: value => {
+  //     form.onItemChange('a.b.c', String(value));
+  //   },
+  // };
+
+  // const extend = {
+  //   'a.b.c': ({ schema }) => {
+  //     return {
+  //       placeholder: 'hahahah' + schema.placeholder,
+  //     };
+  //   },
+  //   'allEnum.select': () => {
+  //     const options = [];
+  //     for (let i = 10; i < 36; i++) {
+  //       const value = i.toString(36) + i;
+  //       options.push({
+  //         label: `Long Label: ${value}`,
+  //         value,
+  //       });
+  //     }
+  //     return { options };
+  //   },
+  // };
+
+  // TODO: form 不传入，也可以用，至少可以展示
+  return (
+    <div>
+      <button onClick={form.submit}>提交</button>
+      <div style={{ height: 40 }}>{JSON.stringify(display[0])}</div>
+      <div style={{ minHeight: 40 }}>{JSON.stringify(display[1])}</div>
+      <div style={{ padding: 24 }}>
+        <button onClick={outsideValidation}>外部校验传入</button>
+        <FormRender
+          // watch={watch}
+          // extend={extend}
+          form={form}
+          schema={schema}
+          initialData={{
+            list: [
+              { userName: '123sdf', selectName: 'b', checkboxName: true },
+              { userName: '123', checkboxName: false },
+            ],
+          }}
+          beforeFinish={beforeFinish}
+          onFinish={onFinish}
+          widgets={{ percent: PercentWidget }}
+          displayType="column"
+        />
+      </div>
+    </div>
+  );
+};
+
+ReactDOM.render(<Demo />, document.getElementById('root'));

--- a/packages/FR1.0/src/mapping.js
+++ b/packages/FR1.0/src/mapping.js
@@ -1,0 +1,60 @@
+export const mapping = {
+  default: 'input',
+  string: 'input',
+  array: 'list',
+  boolean: 'checkbox',
+  integer: 'number',
+  number: 'number',
+  object: 'map',
+  'string:upload': 'upload',
+  'string:date': 'date',
+  'string:dateTime': 'date',
+  'string:time': 'date',
+  'string:textarea': 'textarea',
+  'string:color': 'color',
+  'string:image': 'imageInput',
+  'range:date': 'dateRange',
+  'range:dateTime': 'dateRange',
+  '*?enum': 'select',
+  'array?enum': 'checkboxes',
+  '*?readonly': 'text',
+};
+
+export function getWidgetName(schema, _mapping = mapping) {
+  const { type, format, enum: enums, readonly } = schema;
+
+  // 如果已经注明了渲染widget，那最好
+  // if (schema['ui:widget']) {
+  //   return schema['ui:widget'];
+  // }
+
+  const list = [];
+  if (readonly) {
+    list.push(`${type}?readonly`);
+    list.push('*?readonly');
+  }
+  if (enums) {
+    list.push(`${type}?enum`);
+    // array 默认使用list，array?enum 默认使用checkboxes，*?enum 默认使用select
+    list.push('*?enum');
+  }
+  if (format) {
+    list.push(`${type}:${format}`);
+  }
+  list.push(type); // 放在最后兜底，其他都不match时使用type默认的组件
+  let found = '';
+  list.some(item => {
+    found = _mapping[item];
+    return !!found;
+  });
+  return found;
+}
+
+export const extraSchemaList = {
+  checkbox: {
+    valuePropName: 'checked',
+  },
+  switch: {
+    valuePropName: 'checked',
+  },
+};

--- a/packages/FR1.0/src/otherWidgets/Percent.js
+++ b/packages/FR1.0/src/otherWidgets/Percent.js
@@ -1,0 +1,31 @@
+import React, { useEffect } from 'react';
+import { Progress, Button } from 'antd';
+import { MinusOutlined, PlusOutlined } from '@ant-design/icons';
+
+const App = ({ percent = 0, onPress = () => {} }) => {
+  const increase = () => {
+    let _percent = percent + 10;
+    if (_percent > 100) {
+      _percent = 100;
+    }
+    onPress(_percent);
+  };
+  const decline = () => {
+    let _percent = percent - 10;
+    if (_percent < 0) {
+      _percent = 0;
+    }
+    onPress(_percent);
+  };
+  return (
+    <>
+      <Progress type="circle" percent={percent} />
+      <Button.Group>
+        <Button onClick={decline} icon={<MinusOutlined />} />
+        <Button onClick={increase} icon={<PlusOutlined />} />
+      </Button.Group>
+    </>
+  );
+};
+
+export default App;

--- a/packages/FR1.0/src/reportWebVitals.js
+++ b/packages/FR1.0/src/reportWebVitals.js
@@ -1,0 +1,13 @@
+const reportWebVitals = onPerfEntry => {
+  if (onPerfEntry && onPerfEntry instanceof Function) {
+    import('web-vitals').then(({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
+      getCLS(onPerfEntry);
+      getFID(onPerfEntry);
+      getFCP(onPerfEntry);
+      getLCP(onPerfEntry);
+      getTTFB(onPerfEntry);
+    });
+  }
+};
+
+export default reportWebVitals;

--- a/packages/FR1.0/src/setupTests.js
+++ b/packages/FR1.0/src/setupTests.js
@@ -1,0 +1,5 @@
+// jest-dom adds custom jest matchers for asserting on DOM nodes.
+// allows you to do things like:
+// expect(element).toHaveTextContent(/react/i)
+// learn more: https://github.com/testing-library/jest-dom
+import '@testing-library/jest-dom';

--- a/packages/FR1.0/src/useForm.js
+++ b/packages/FR1.0/src/useForm.js
@@ -1,0 +1,206 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+import { useEffect, useRef } from 'react';
+import { getDataPath, removeEmptyItemFromList } from './utils';
+import { validateAll } from './validator';
+import { useSet } from './hooks';
+import { set, unset, sortedUniqBy } from 'lodash';
+
+export const useForm = () => {
+  const [state, setState] = useSet({
+    formData: {}, // TODO: 初始值从外部传入
+    submitData: {},
+    errorFields: [],
+    isValidating: false, // 含义有点变化了，只要提交了没有过校验，就一直会是true，这块有点投机取巧，叫hasValidated 可能更合适
+    isSubmitting: false,
+    isEditing: false, // 是否在编辑状态。主要用于优化体验，用户编辑时减少不必要的运算
+  });
+
+  const schemaRef = useRef();
+  const flattenRef = useRef();
+
+  const schema = schemaRef.current || {};
+  const flatten = flattenRef.current || {};
+
+  const {
+    formData,
+    submitData,
+    errorFields = [],
+    isValidating,
+    isSubmitting,
+    isEditing,
+    // statusTree, // 和formData一个结构，但是每个元素是 { $touched } 存放那些在schema里无需表达的状态, 看看是否只有touched。目前statusTree没有被使用
+  } = state;
+
+  useEffect(() => {
+    let isRequired = false;
+    if (isValidating) isRequired = true;
+    validateAll({
+      formData,
+      schema: schemaRef.current,
+      isRequired,
+    }).then(res => {
+      console.log(res, 'errorFields');
+      setState({ errorFields: res });
+    });
+  }, [formData, isValidating]);
+
+  const setEditing = isEditing => {
+    setState({ isEditing });
+  };
+
+  const onItemChange = (path, value) => {
+    if (typeof path !== 'string') return;
+    if (path === '#') {
+      setState({ formData: { ...value } });
+      return;
+    }
+    const newFormData = set(formData, path, value);
+    setState({ formData: { ...newFormData } });
+  };
+
+  // TODO: 全局的没有path, 这个函数要这么写么。。全局的，可以path = #
+  // errorFields: [
+  //   { name: 'a.b.c', errors: ['Please input your Password!', 'something else is wrong'] },
+  // ]
+
+  const bindSchema = ({ schema, flatten }) => {
+    schemaRef.current = schema;
+    flattenRef.current = flatten;
+  };
+
+  // TODO: 外部校验的error要和本地的合并么？
+  // TODO!: 这块要优化一下吧
+  const setErrorFields = error => {
+    let newErrorFields = [];
+    if (Array.isArray(error)) {
+      newErrorFields = [...error, ...errorFields];
+    } else if (error && error.name) {
+      newErrorFields = [error, ...errorFields];
+    } else {
+      console.log('error format is wrong');
+    }
+    newErrorFields = sortedUniqBy(newErrorFields, item => item.name);
+    console.log('newErrorFields', newErrorFields);
+    setState({ errorFields: newErrorFields });
+  };
+
+  const removeValidation = _path => {
+    if (!_path || _path === '#') {
+      setState({ errorFields: [] });
+    }
+    let path;
+    if (typeof _path === 'string') {
+      path = _path;
+    } else if (Array.isArray(_path) && typeof _path[0] === 'string') {
+      path = _path[0];
+    } else {
+      // 说明有传参有问题，直接结束 TODO: 后续可给个提示
+      return;
+    }
+
+    setState(({ errorFields }) => {
+      let newErrorFields = errorFields.filter(
+        item => item.name.indexOf(path) === -1
+      );
+      return {
+        errorFields: newErrorFields,
+      };
+    });
+  };
+
+  // TODO: 提取出来，重新写一份，注意要处理async
+
+  const getValues = () => formData;
+
+  // 提交前需要先处理formData的逻辑
+  const processData = data => {
+    let _data = JSON.parse(JSON.stringify(data));
+    // 1. bind = false 的处理
+    const unbindKeys = Object.keys(flatten)
+      .map(key => {
+        const bind =
+          flatten[key] && flatten[key].schema && flatten[key].schema.bind;
+        if (bind === false) {
+          return key;
+        }
+        return undefined;
+      })
+      .filter(key => !!key);
+    const removeUnbindData = _data => {
+      unbindKeys.forEach(key => {
+        if (key.indexOf('[]') === -1) {
+          _data = unset(_data, key); // TODO: 光remove了一个key，如果遇到remove了那个key上层的object为空了，object是不是也要去掉。。。不过感觉是伪需求
+        } else {
+          // const keys = key.split('[]').filter(k => !!k);
+          // TODO: 贼复杂，之后写吧
+        }
+      });
+    };
+    removeUnbindData(_data);
+    // 2. 去掉list里面所有的空值
+    _data = removeEmptyItemFromList(_data);
+
+    return _data;
+  };
+
+  const submit = () => {
+    setState({ isValidating: true, isSubmitting: true });
+    //  https://formik.org/docs/guides/form-submission
+    // TODO: 更多的处理，注意处理的时候一定要是copy一份formData，否则submitData会和表单操作实时同步的。。而不是submit再变动了
+
+    // 开始校验。如果校验写在每个renderField，也会有问题，比如table第一页以外的数据是不渲染的，所以都不会触发，而且校验还有异步问题
+    validateAll({ formData, schema: schemaRef.current }).then(res => {
+      console.log(res, 'validate result');
+      // setState({ errorFields: res });
+      if (res && res.length > 0) {
+        setState({ isSubmitting: false });
+        return;
+      }
+      Promise.resolve(processData(formData)).then(res => {
+        console.log(res);
+        setState({
+          isValidating: false,
+          submitData: res,
+        });
+      });
+    });
+  };
+
+  const resetFields = () => {
+    setState({ formData: {} });
+  };
+
+  const setValue = (id, value, dataIndex) => {
+    let path = id;
+    if (dataIndex && Array.isArray(dataIndex)) {
+      path = getDataPath(id, dataIndex);
+    }
+    onItemChange(path, value);
+  };
+
+  const endSubmitting = () =>
+    setState({ isSubmitting: false, isValidating: false });
+
+  const form = {
+    // state
+    formData,
+    schema,
+    // methods
+    onItemChange,
+    setValue,
+    getValues,
+    resetFields,
+    submit,
+    submitData,
+    errorFields,
+    isSubmitting,
+    isValidating,
+    endSubmitting,
+    setErrorFields,
+    removeValidation,
+    isEditing,
+    setEditing,
+    bindSchema,
+  };
+  return form;
+};

--- a/packages/FR1.0/src/utils.js
+++ b/packages/FR1.0/src/utils.js
@@ -1,0 +1,672 @@
+import deepClone from 'clone';
+import { get } from 'lodash';
+
+// 后面三个参数都是内部递归使用的，将schema的树形结构扁平化成一层, 每个item的结构
+// {
+//   parent: '#',
+//   schema: ...,
+//   children: []
+// }
+
+window.blog = value => {
+  console.log('%ccommon:', 'color: #00A7F7; font-weight: 500;', value);
+};
+
+window.rlog = value => {
+  console.log('%cwarning:', 'color: #f50; font-weight: 500;', value);
+};
+
+window.glog = value => {
+  console.log('%csuccess:', 'color: #87d068; font-weight: 500;', value);
+};
+
+window.plog = value => {
+  console.log('%cspecial:', 'color: #722ed1; font-weight: 500;', value);
+};
+
+export function isCheckBoxType(schema) {
+  return (
+    schema && schema.type === 'boolean' && schema['ui:widget'] !== 'switch'
+  ); // TODO: 感觉有点不准
+}
+
+// a[].b.c => a.b.c
+function removeBrackets(string) {
+  if (typeof string === 'string') {
+    return string.replace(/\[\]/g, '');
+  } else {
+    return string;
+  }
+}
+
+export function getParentPath(path) {
+  if (typeof path === 'string') {
+    const pathArr = path.split('.');
+    if (pathArr.length === 1) {
+      return '#';
+    }
+    pathArr.pop();
+    return pathArr.join('.');
+  }
+  return '#';
+}
+
+export function getValueByPath(formData, path) {
+  if (path === '#') {
+    return formData;
+  } else if (typeof path === 'string') {
+    return get(formData, path);
+  }
+}
+
+//  path: 'a.b[1].c[0]' => { id: 'a.b[].c[]'  dataIndex: [1,0] }
+export function destructDataPath(path) {
+  let id;
+  let dataIndex;
+  if (path === '#') {
+    return { id: '#', dataIndex: [] };
+  }
+  if (typeof path !== 'string') {
+    throw Error(`path ${path} is not a string!!! Something wrong here`);
+  }
+  const pattern = /\[[0-9]+\]/g;
+  const matchList = path.match(pattern);
+  if (!matchList) {
+    id = path;
+  } else {
+    id = path.replace(pattern, '[]');
+    // 这个是match下来的结果，可安全处理
+    dataIndex = matchList.map(item =>
+      Number(item.substring(1, item.length - 1))
+    );
+  }
+  return { id, dataIndex };
+}
+
+// id: 'a.b[].c[]'  dataIndex: [1,0] =>  'a.b[1].c[0]'
+export function getDataPath(id, dataIndex) {
+  if (id === '#') {
+    return id;
+  }
+  if (typeof id !== 'string') {
+    throw Error(`id ${id} is not a string!!! Something wrong here`);
+  }
+  let _id = id;
+  if (Array.isArray(dataIndex)) {
+    // const matches = id.match(/\[\]/g) || [];
+    // const count = matches.length;
+    dataIndex.forEach(item => {
+      _id = _id.replace(/\[\]/, `[${item}]`);
+    });
+  }
+  return removeBrackets(_id);
+}
+
+export function isListType(schema) {
+  return schema.type === 'array' && schema.items && schema.enum === undefined;
+}
+
+export function isObjType(schema) {
+  return schema.type === 'object' && schema.properties;
+}
+
+// TODO: 检验是否丢进去各种schema都能兜底不会crash
+export function flattenSchema(_schema = {}, name = '#', parent, result = {}) {
+  const schema = deepClone(_schema); // TODO: 是否需要deepClone，这个花费是不是有点大
+  let _name = name;
+  if (!schema.$id) {
+    schema.$id = _name; // 给生成的schema添加一个唯一标识，方便从schema中直接读取
+  }
+  const children = [];
+  if (isObjType(schema)) {
+    Object.entries(schema.properties).forEach(([key, value]) => {
+      const _key = isListType(value) ? key + '[]' : key;
+      const uniqueName = _name === '#' ? _key : _name + '.' + _key;
+      children.push(uniqueName);
+      flattenSchema(value, uniqueName, _name, result);
+    });
+    // schema.properties = {};
+  }
+  if (isListType(schema)) {
+    Object.entries(schema.items.properties).forEach(([key, value]) => {
+      const _key = isListType(value) ? key + '[]' : key;
+      const uniqueName = _name === '#' ? _key : _name + '.' + _key;
+      children.push(uniqueName);
+      flattenSchema(value, uniqueName, _name, result);
+    });
+    // schema.items.properties = {};
+  }
+
+  const rules = Array.isArray(schema.rules) ? [...schema.rules] : [];
+  if (['boolean', 'function', 'string'].indexOf(typeof schema.required) > -1) {
+    rules.push({ required: schema.required }); // TODO: 万一内部已经用重复的required规则？
+  }
+
+  if (schema.type) {
+    // Check: 为啥一定要有type？
+    // TODO: 没有想好 validation 的部分
+    result[_name] = { parent, schema: schema, children, rules };
+  }
+  return result;
+}
+
+//////////   old
+
+function stringContains(str, text) {
+  return str.indexOf(text) > -1;
+}
+
+export const isObject = a =>
+  stringContains(Object.prototype.toString.call(a), 'Object');
+
+// 克隆对象
+export function clone(data) {
+  try {
+    return JSON.parse(JSON.stringify(data));
+  } catch (e) {
+    return data;
+  }
+}
+
+// '3' => true, 3 => true, undefined => false
+export function isLooselyNumber(num) {
+  if (typeof num === 'number') return true;
+  if (typeof num === 'string') {
+    return !Number.isNaN(Number(num));
+  }
+  return false;
+}
+
+export function isCssLength(str) {
+  if (typeof str !== 'string') return false;
+  return str.match(/^([0-9])*(%|px|rem|em)$/i);
+}
+
+// 深度对比
+export function isDeepEqual(param1, param2) {
+  if (param1 === undefined && param2 === undefined) return true;
+  else if (param1 === undefined || param2 === undefined) return false;
+  if (param1 === null && param2 === null) return true;
+  else if (param1 === null || param2 === null) return false;
+  else if (param1.constructor !== param2.constructor) return false;
+
+  if (param1.constructor === Array) {
+    if (param1.length !== param2.length) return false;
+    for (let i = 0; i < param1.length; i++) {
+      if (param1[i].constructor === Array || param1[i].constructor === Object) {
+        if (!isDeepEqual(param1[i], param2[i])) return false;
+      } else if (param1[i] !== param2[i]) return false;
+    }
+  } else if (param1.constructor === Object) {
+    if (Object.keys(param1).length !== Object.keys(param2).length) return false;
+    for (let i = 0; i < Object.keys(param1).length; i++) {
+      const key = Object.keys(param1)[i];
+      if (
+        param1[key] &&
+        typeof param1[key] !== 'number' &&
+        (param1[key].constructor === Array ||
+          param1[key].constructor === Object)
+      ) {
+        if (!isDeepEqual(param1[key], param2[key])) return false;
+      } else if (param1[key] !== param2[key]) return false;
+    }
+  } else if (param1.constructor === String || param1.constructor === Number) {
+    return param1 === param2;
+  }
+  return true;
+}
+
+// 时间组件
+export function getFormat(format) {
+  let dateFormat;
+  switch (format) {
+    case 'date':
+      dateFormat = 'YYYY-MM-DD';
+      break;
+    case 'time':
+      dateFormat = 'HH:mm:ss';
+      break;
+    default:
+      // dateTime
+      dateFormat = 'YYYY-MM-DD HH:mm:ss';
+  }
+  return dateFormat;
+}
+
+export function hasRepeat(list) {
+  return list.find(
+    (x, i, self) =>
+      i !== self.findIndex(y => JSON.stringify(x) === JSON.stringify(y))
+  );
+}
+
+// ----------------- schema 相关
+
+// 合并propsSchema和UISchema。由于两者的逻辑相关性，合并为一个大schema能简化内部处理
+export function combineSchema(propsSchema = {}, uiSchema = {}) {
+  const propList = getChildren(propsSchema);
+  const newList = propList.map(p => {
+    const { name } = p;
+    const { type, enum: options, properties, items } = p.schema;
+    const isObj = type === 'object' && properties;
+    const isArr = type === 'array' && items && !options; // enum + array 代表的多选框，没有sub
+    const ui = name && uiSchema[p.name];
+    if (!ui) {
+      return p;
+    }
+    // 如果是list，递归合并items
+    if (isArr) {
+      const newItems = combineSchema(items, ui.items || {});
+      return { ...p, schema: { ...p.schema, ...ui, items: newItems } };
+    }
+    // object递归合并整个schema
+    if (isObj) {
+      const newSchema = combineSchema(p.schema, ui);
+      return { ...p, schema: newSchema };
+    }
+    return { ...p, schema: { ...p.schema, ...ui } };
+  });
+
+  const newObj = {};
+  newList.forEach(s => {
+    newObj[s.name] = s.schema;
+  });
+
+  const topLevelUi = {};
+  Object.keys(uiSchema).forEach(key => {
+    if (typeof key === 'string' && key.substring(0, 3) === 'ui:') {
+      topLevelUi[key] = uiSchema[key];
+    }
+  });
+  if (isEmpty(newObj)) {
+    return { ...propsSchema, ...topLevelUi };
+  }
+  return { ...propsSchema, ...topLevelUi, properties: newObj };
+}
+
+function isEmpty(obj) {
+  return Object.keys(obj).length === 0;
+}
+
+// 获得propsSchema的children
+function getChildren(schema) {
+  if (!schema) return [];
+  const {
+    // object
+    properties,
+    // array
+    items,
+    type,
+  } = schema;
+  if (!properties && !items) {
+    return [];
+  }
+  let schemaSubs = {};
+  if (type === 'object') {
+    schemaSubs = properties;
+  }
+  if (type === 'array') {
+    schemaSubs = items;
+  }
+  return Object.keys(schemaSubs).map(name => ({
+    schema: schemaSubs[name],
+    name,
+  }));
+}
+
+// 合并多个schema树，比如一个schema的树节点是另一个schema
+export function combine() {}
+
+// 代替eval的函数
+export const parseString = string =>
+  Function('"use strict";return (' + string + ')')();
+
+// 解析函数字符串值
+export const evaluateString = (string, formData, rootValue) =>
+  Function(`"use strict";
+    const rootValue = ${JSON.stringify(rootValue)};
+    const formData = ${JSON.stringify(formData)};
+    return (${string})`)();
+
+// 判断schema的值是是否是“函数”
+// JSON无法使用函数值的参数，所以使用"{{...}}"来标记为函数，也可使用@标记，不推荐。
+export function isExpression(func) {
+  if (typeof func === 'function') {
+    const funcString = func.toString();
+    return (
+      funcString.indexOf('formData') > -1 ||
+      funcString.indexOf('rootValue') > -1 // Check: 这个旧版兼容，值得么
+    );
+  }
+  // 这样的pattern {{.....}}
+  const pattern = /^({{){1}.+(}}){1}$/g;
+  if (typeof func === 'string' && func.match(pattern)) {
+    return true;
+    // return func.substring(2, func.length - 2);
+  }
+  return false;
+}
+
+// TODO: dataPath 是 array 的情况？
+export function parseSingleExpression(func, formData, _dataPath) {
+  let dataPath = _dataPath;
+  if (Array.isArray(_dataPath)) {
+    dataPath = _dataPath[0]; // Check: 就不要去支持array的情况下去使用rootValue，逻辑上就是不通的, 这里取第一个值的，是默认所有值的parent都一样。
+  }
+  const parentPath = getParentPath(dataPath);
+  const parent = getValueByPath(formData, parentPath);
+  if (typeof func === 'function') {
+    try {
+      return func(formData, parent);
+    } catch (e) {
+      console.error(`${dataPath}表达式解析错误`);
+      return;
+    }
+  } else if (typeof func === 'string') {
+    const parser = match => {
+      const path = match.replace('formData.', '');
+      const result = get(formData, path);
+      return result;
+    };
+    const parser2 = match => {
+      const replaceValue = parentPath === '#' ? '' : parentPath + '.';
+      const path = match.replace('rootValue.', replaceValue);
+      const result = get(formData, path);
+      return result;
+    };
+    const funcBody = func.substring(2, func.length - 2);
+    const match1 = /(formData\.){1}[a-zA-Z0-9.$_[]]+/;
+    const match2 = /(rootValue\.){1}[a-zA-Z0-9.$_[]]+/; // 这里叫rootValue是为了兼容旧的
+    const str = `"use strict";
+    var formData = ${JSON.stringify(formData)};
+    var rootValue = ${JSON.stringify(parent)};
+    return (${funcBody
+      .replace(match1, v => JSON.stringify(parser(v)))
+      .replace(match2, v => JSON.stringify(parser2(v)))})`;
+    try {
+      return Function(str)();
+    } catch (error) {
+      return func;
+    }
+  } else return func;
+}
+
+export const schemaContainsExpression = schema => {
+  return Object.keys(schema).some(key => {
+    const value = schema[key];
+    if (['string', 'function'].indexOf(typeof value) > -1) {
+      return isExpression(value);
+    } else if (isObject(value)) {
+      return schemaContainsExpression(value);
+    }
+    return false;
+  });
+};
+
+export const parseAllExpression = (_schema, formData, dataPath) => {
+  const schema = clone(_schema);
+  Object.keys(schema).forEach(key => {
+    const value = schema[key];
+    if (['string', 'function'].indexOf(typeof value) > -1) {
+      if (isExpression(value)) {
+        schema[key] = parseSingleExpression(value, formData, dataPath);
+      }
+    }
+  });
+  return schema;
+};
+
+// 判断schema中是否有属性值是函数表达式
+export function isFunctionSchema(schema) {
+  return Object.keys(schema).some(key => {
+    if (typeof schema[key] === 'function') {
+      return true;
+    } else if (typeof schema[key] === 'string') {
+      return isExpression(schema[key]);
+    } else if (typeof schema[key] === 'object') {
+      return isFunctionSchema(schema[key]);
+    } else {
+      return false;
+    }
+  });
+}
+
+// 例如当前item的id = '#/obj/input'  propName: 'ui:labelWidth' 往上一直找，直到找到第一个不是undefined的值 TODO: 看看是否ok
+export const getParentProps = (propName, id, flatten) => {
+  try {
+    const item = flatten[id];
+    if (item.schema[propName] !== undefined) return item.schema[propName];
+    if (item && item.parent) {
+      const parentSchema = flatten[item.parent].schema;
+      if (parentSchema[propName] !== undefined) {
+        return parentSchema[propName];
+      } else {
+        return getParentProps(propName, item.parent, flatten);
+      }
+    }
+  } catch (error) {
+    return undefined;
+  }
+};
+
+export const getSaveNumber = () => {
+  const searchStr = localStorage.getItem('SAVES');
+  if (searchStr) {
+    try {
+      const saves = JSON.parse(searchStr);
+      const length = saves.length;
+      if (length) return length + 1;
+    } catch (error) {
+      return 1;
+    }
+  } else {
+    return 1;
+  }
+};
+
+export function looseJsonParse(obj) {
+  return Function('"use strict";return (' + obj + ')')();
+}
+
+// 获得propsSchema的children
+function getChildren2(schema) {
+  if (!schema) return [];
+  const {
+    // object
+    properties,
+    // array
+    items,
+    type,
+  } = schema;
+  if (!properties && !items) {
+    return [];
+  }
+  let schemaSubs = {};
+  if (type === 'object') {
+    schemaSubs = properties;
+  }
+  if (type === 'array') {
+    schemaSubs = items.properties;
+  }
+  return Object.keys(schemaSubs).map(name => ({
+    schema: schemaSubs[name],
+    name,
+  }));
+}
+
+export const oldSchemaToNew = schema => {
+  if (schema && schema.propsSchema) {
+    const { propsSchema, ...rest } = schema;
+    return { schema: propsSchema, ...rest };
+  }
+  return schema;
+};
+
+export const newSchemaToOld = setting => {
+  if (setting && setting.schema) {
+    const { schema, ...rest } = setting;
+    return { propsSchema: schema, ...rest };
+  }
+  return setting;
+};
+
+// from FR
+
+export const getEnum = schema => {
+  if (!schema) return undefined;
+  const itemEnum = schema && schema.items && schema.items.enum;
+  const schemaEnum = schema && schema.enum;
+  return itemEnum ? itemEnum : schemaEnum;
+};
+
+export const getArray = (arr, defaultValue = []) => {
+  if (Array.isArray(arr)) return arr;
+  return defaultValue;
+};
+
+export const isEmail = value => {
+  const regex = '^[a-zA-Z0-9_-]+@[a-zA-Z0-9_-]+(.[a-zA-Z0-9_-]+)+$';
+  if (value && new RegExp(regex).test(value)) {
+    return true;
+  }
+  return false;
+};
+
+export function defaultGetValueFromEvent(valuePropName, ...args) {
+  const event = args[0];
+  if (event && event.target && valuePropName in event.target) {
+    return event.target[valuePropName];
+  }
+  return event;
+}
+
+export const getKeyFromPath = path => {
+  try {
+    const keyList = path.split('.');
+    const last = keyList.slice(-1)[0];
+    return last;
+  } catch (error) {
+    console.error(error, 'getKeyFromPath');
+    return '';
+  }
+};
+
+// 更多的值获取
+export const getDisplayValue = (value, schema) => {
+  if (typeof value === 'boolean') {
+    return value ? 'yes' : 'no';
+  }
+  if (isObjType(schema) || isListType(schema)) {
+    return '-';
+  }
+  if (Array.isArray(schema.enum) && Array.isArray(schema.enumNames)) {
+    try {
+      return schema.enumNames[schema.enum.indexOf(value)];
+    } catch (error) {
+      return value;
+    }
+  }
+  return value;
+};
+
+// 去掉数组里的空元素 {a: [null, {x:1}]} => {a: [{x:1}]}
+export const removeEmptyItemFromList = formData => {
+  let result = {};
+  if (isObject(formData)) {
+    Object.keys(formData).forEach(key => {
+      result[key] = removeEmptyItemFromList(formData[key]);
+    });
+  } else if (Array.isArray(formData)) {
+    result = formData.filter(item => {
+      if (item && JSON.stringify(item) !== '{}') {
+        return true;
+      }
+      return false;
+    });
+  } else {
+    result = formData;
+  }
+  return result;
+};
+
+export const getDscriptorFromSchema = ({ schema, isRequired = true }) => {
+  let result = {};
+  if (isObjType(schema)) {
+    result.type = 'object';
+    if (isRequired && schema.required) {
+      result.required = true;
+    }
+    result.fields = {};
+    Object.keys(schema.properties).forEach(key => {
+      const item = schema.properties[key]; // bind 的逻辑写这里 TODO:
+      result.fields[key] = getDscriptorFromSchema({ schema: item, isRequired });
+    });
+  } else if (isListType(schema)) {
+    result.type = 'array';
+    if (isRequired && schema.required) {
+      result.required = true;
+    }
+    result.defaultField = { type: 'object', fields: {} }; // 目前就默认只有object类型的 TODO:
+    Object.keys(schema.items.properties).forEach(key => {
+      const item = schema.items.properties[key];
+      result.defaultField.fields[key] = getDscriptorFromSchema({
+        schema: item,
+        isRequired,
+      });
+    });
+  } else {
+    // if (schema.type) {
+    //   result.type = schema.type;
+    // }
+    const addType = item => {
+      if (schema.type) return { ...item, type: schema.type };
+      return item;
+    };
+    const { required, ...rest } = schema;
+    if (isRequired && schema.required) {
+      rest.required = true;
+    }
+    if (schema.rules) {
+      if (Array.isArray(schema.rules)) {
+        const _rules = schema.rules.map(item => addType(item));
+        result = [rest, ..._rules];
+      } else if (isObject(schema.rules)) {
+        result = [rest, addType(schema.rules)];
+      } else {
+        result = rest;
+      }
+    } else {
+      // TODO1: 补齐
+      result = rest;
+    }
+    switch (schema.type) {
+      case 'range':
+        result.type = 'array';
+        break;
+      default:
+        break;
+    }
+  }
+  return result;
+};
+
+// async-validator 产出的path没法用，转一下
+// "list.1.userName" => "list[1].userName"
+export const formatPathFromValidator = err => {
+  const errArr = err.split('.');
+  return errArr
+    .map(item => {
+      if (isNaN(Number(item))) {
+        return item;
+      } else {
+        return `[${item}]`;
+      }
+    })
+    .reduce((a, b) => {
+      if (b[0] === '[' || a === '') {
+        return a + b;
+      } else {
+        return a + '.' + b;
+      }
+    }, '');
+};

--- a/packages/FR1.0/src/validation.js
+++ b/packages/FR1.0/src/validation.js
@@ -1,0 +1,40 @@
+// 这个组件已经没用了，可以删了 TODO:
+
+import { isObject } from './utils';
+
+export const validateSingleRule = (rule, value) => {
+  if (isObject(rule)) {
+    if (rule.required === true) {
+      if (value) return;
+      return rule.message || `it is required`;
+    }
+    if (value === undefined || value === null) return;
+    // 按一个个rule来写比较快
+    if (!Number.isNaN(Number(rule.min))) {
+      switch (typeof value) {
+        case 'number':
+          if (value <= rule.min) return rule.message || '太短';
+          break;
+        case 'string':
+          if (value.length <= rule.min) return rule.message || '太短';
+          break;
+        default:
+          break;
+      }
+      return;
+    }
+    if (!Number.isNaN(Number(rule.max))) {
+      switch (typeof value) {
+        case 'number':
+          if (value > rule.max) return rule.message || '太长';
+          break;
+        case 'string':
+          if (value.length > rule.max) return rule.message || '太长';
+          break;
+        default:
+          break;
+      }
+      return;
+    }
+  }
+};

--- a/packages/FR1.0/src/validator.js
+++ b/packages/FR1.0/src/validator.js
@@ -1,0 +1,210 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+import { getDscriptorFromSchema, formatPathFromValidator } from './utils';
+import Validator from 'async-validator';
+
+export const validateAll = ({ formData, schema, isRequired = true }) => {
+  const descriptor = getDscriptorFromSchema({
+    schema,
+    isRequired,
+  }).fields;
+  // console.log(schema, 'schema', descriptor, 'descriptor', formData, 'formData');
+
+  const cn = {
+    required: '%s 必填',
+  };
+
+  const validator = new Validator(descriptor);
+  validator.messages(cn);
+  return validator.validate(formData).catch(({ errors, fields }) => {
+    console.log(errors, fields, 'result');
+    const normalizedErrors = errors.map(err => {
+      const _path = formatPathFromValidator(err.field);
+      return { name: _path, error: [err.message] };
+    });
+    let _errorFields = [];
+    normalizedErrors.forEach(item => {
+      const matchIndex = _errorFields.findIndex(ele => ele.name === item.name);
+      if (matchIndex === -1) {
+        _errorFields.push(item);
+      } else {
+        _errorFields[matchIndex].error = [
+          ..._errorFields[matchIndex].error,
+          ...item.error,
+        ];
+      }
+    });
+    return _errorFields;
+    // errors for address.street, address.city, address.zip
+  });
+};
+
+// useEffect(() => {
+//   const handleErrors = (a, b) => console.log(a, b);
+
+//   const descriptor = {
+//     roles: {
+//       type: 'array',
+//       required: true,
+//       defaultField: {
+//         type: 'object',
+//         fields: {
+//           street: { type: 'string', required: true },
+//           city: { type: 'string', required: true, message: 'invalid zip' },
+//           zip: [
+//             {
+//               type: 'string',
+//               required: true,
+//               message: 'invalid zip',
+//             },
+//             {
+//               len: 8,
+//               message: 'xxx',
+//             },
+//           ],
+//           res: {
+//             type: 'array',
+//             required: true,
+//             defaultField: {
+//               type: 'object',
+//               fields: {
+//                 city: { type: 'string', required: true },
+//               },
+//             },
+//           },
+//         },
+//       },
+//     },
+//     name: {
+//       type: 'string',
+//       required: true,
+//       validator: (rule, value) => value === 'muji',
+//     },
+//     age: {
+//       type: 'number',
+//       min: 12,
+//       max: 13,
+//       message: 'asdfadsf',
+//       // asyncValidator: (rule, value) => {
+//       //   return new Promise((resolve, reject) => {
+//       //     if (value < 18) {
+//       //       reject('too young'); // reject with error message
+//       //     } else {
+//       //       resolve();
+//       //     }
+//       //   });
+//       // },
+//     },
+//   };
+//   const validator = new Validator(descriptor);
+
+//   // validator.validate({ name: 'muji' }, (errors, fields) => {
+//   //   if (errors) {
+//   //     // validation failed, errors is an array of all errors
+//   //     // fields is an object keyed by field name with an array of
+//   //     // errors per field
+//   //     return handleErrors(errors, fields);
+//   //   }
+//   //   // validation passed
+//   // });
+
+//   validator
+//     .validate({ name: 'muji', age: 16, roles: [{ zip: '123', res: [{}] }] })
+//     .then(() => {
+//       // validation passed or without error message
+//     })
+//     .catch(({ errors, fields }) => {
+//       return handleErrors(errors, fields);
+//     });
+// }, []);
+
+var d3 = {
+  list: {
+    type: 'array',
+    defaultField: {
+      type: 'object',
+      fields: {
+        userName: [
+          {
+            bind: false,
+            title: 'User Name',
+            type: 'string',
+            rules: [
+              {
+                min: 5,
+                message: '长度需要大于5',
+              },
+              {
+                max: 12,
+              },
+            ],
+          },
+          {
+            min: 5,
+            message: '长度需要大于5',
+          },
+          {
+            max: 12,
+          },
+        ],
+        selectName: {
+          title: '单选',
+          type: 'string',
+          enum: ['a', 'b', 'c'],
+          enumNames: ['早', '中', '晚'],
+          required: true,
+        },
+        checkboxName: {
+          title: '是否判断',
+          type: 'boolean',
+          valuePropName: 'checked',
+        },
+      },
+    },
+  },
+};
+
+var d2 = {
+  list: {
+    type: 'array',
+    defaultField: {
+      type: 'object',
+      fields: {
+        userName: [
+          {
+            bind: false,
+            title: 'User Name',
+            type: 'string',
+            rules: [
+              {
+                min: 5,
+                message: '长度需要大于5',
+              },
+              {
+                max: 12,
+              },
+            ],
+          },
+          {
+            min: 5,
+            message: '长度需要大于5',
+          },
+          {
+            max: 12,
+          },
+        ],
+        selectName: {
+          title: '单选',
+          type: 'string',
+          enum: ['a', 'b', 'c'],
+          enumNames: ['早', '中', '晚'],
+          required: true,
+        },
+        checkboxName: {
+          title: '是否判断',
+          type: 'boolean',
+          valuePropName: 'checked',
+        },
+      },
+    },
+  },
+};

--- a/packages/FR1.0/src/widgets/antd/ImageInput.js
+++ b/packages/FR1.0/src/widgets/antd/ImageInput.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { PictureOutlined } from '@ant-design/icons';
+import { Input, Popover } from 'antd';
+
+const DEFAULT_IMG =
+  'https://img.alicdn.com/tfs/TB14tSiKhTpK1RjSZFKXXa2wXXa-354-330.png';
+
+const PreviewNode = ({ value }) => {
+  return (
+    <Popover
+      content={
+        <img
+          src={value || DEFAULT_IMG}
+          alt="图片地址错误"
+          className="fr-preview-image"
+        />
+      }
+      className="fr-preview"
+      placement="bottom"
+    >
+      <PictureOutlined />
+    </Popover>
+  );
+};
+
+export default function imageInput({ onChange, options, disabled, value }) {
+  return (
+    <Input
+      value={value}
+      type="text"
+      disabled={disabled}
+      addonAfter={<PreviewNode value={value} />}
+      onChange={onChange}
+      {...options}
+    />
+  );
+}

--- a/packages/FR1.0/src/widgets/antd/checkboxes.js
+++ b/packages/FR1.0/src/widgets/antd/checkboxes.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import { Checkbox } from 'antd';
+
+export default function Checkboxes({
+  schema,
+  value,
+  onChange,
+  disabled,
+  readOnly,
+  options,
+}) {
+  const { enum: enums, enumNames } = schema || {};
+  const _value = value && Array.isArray(value) ? value : [];
+  if (Array.isArray(enums)) {
+    return (
+      <Checkbox.Group
+        disabled={disabled || readOnly}
+        value={_value}
+        onChange={onChange}
+        {...options}
+      >
+        {enums.map((val, index) => (
+          <Checkbox value={val} key={index}>
+            <span
+              // eslint-disable-next-line react/no-danger
+              dangerouslySetInnerHTML={{
+                __html:
+                  enumNames && Array.isArray(enumNames)
+                    ? enumNames[index]
+                    : val,
+              }}
+            />
+          </Checkbox>
+        ))}
+      </Checkbox.Group>
+    );
+  }
+  return null;
+}

--- a/packages/FR1.0/src/widgets/antd/color.js
+++ b/packages/FR1.0/src/widgets/antd/color.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import ColorPicker from 'rc-color-picker';
+import { Input } from 'antd';
+import 'rc-color-picker/assets/index.css';
+
+export default function color(p) {
+  const { format } = p.schema;
+  const onPickerChange = e => {
+    if (p.disabled || p.readonly) return;
+    p.onChange(e.color);
+  };
+  const onInputChange = e => {
+    // const isHex = value.match(/^(#{0,1})([0-9A-F]{6})$/i);
+    p.onChange(e.target.value);
+  };
+
+  return (
+    <div className="fr-color-picker">
+      {
+        <ColorPicker
+          type={format}
+          animation="slide-up"
+          color={p.value ? p.value : '#ffffff'}
+          onChange={onPickerChange}
+        />
+      }
+      {p.readonly ? (
+        <span>{p.value || '#ffffff'}</span>
+      ) : (
+        <Input
+          placeholder="#ffffff"
+          disabled={p.disabled}
+          value={p.value}
+          onChange={onInputChange}
+        />
+      )}
+    </div>
+  );
+}

--- a/packages/FR1.0/src/widgets/antd/date.js
+++ b/packages/FR1.0/src/widgets/antd/date.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import moment from 'moment';
+import { DatePicker, TimePicker } from 'antd';
+import { getFormat } from '../../utils';
+
+// TODO: 不要使用moment，使用dayjs
+export default p => {
+  let { format = 'dateTime' } = p.schema;
+  if (p.options && p.options.format) {
+    format = p.options.format;
+  }
+  const DateComponent = format === 'time' ? TimePicker : DatePicker;
+  const dateFormat = getFormat(format);
+  // week的时候会返回 2020-31周 quarter会返回 2020-Q2 需要处理之后才能被 moment
+  let _value = p.value || '';
+  if (typeof _value === 'string') {
+    if (format === 'week') {
+      _value = _value.substring(0, _value.length - 1);
+    }
+    if (format === 'quarter') {
+      _value = _value.replace('Q', '');
+    }
+  }
+  if (_value) {
+    _value = moment(_value, dateFormat);
+  }
+
+  const placeholderObj = p.description ? { placeholder: p.description } : {};
+
+  const onChange = (value, string) => p.onChange(string);
+
+  const dateParams = {
+    ...placeholderObj,
+    ...p.options,
+    value: _value,
+    style: { width: '100%' },
+    disabled: p.disabled || p.readOnly,
+    onChange,
+  };
+
+  // TODO: format是在options里自定义的情况，是否要判断一下要不要showTime
+  if (format === 'dateTime') {
+    dateParams.showTime = true;
+  }
+
+  if (['week', 'month', 'quarter', 'year'].indexOf(format) > -1) {
+    dateParams.picker = format;
+  }
+
+  return <DateComponent {...dateParams} />;
+};

--- a/packages/FR1.0/src/widgets/antd/dateRange.js
+++ b/packages/FR1.0/src/widgets/antd/dateRange.js
@@ -1,0 +1,18 @@
+/**
+ * Updated by Tw93 on 2019-12-08.
+ * 日历多选组件
+ */
+
+import { DatePicker, TimePicker } from 'antd';
+import RangeHoc from '../../components/rangeHoc';
+
+const { RangePicker: DateRange } = DatePicker;
+const { RangePicker: TimeRange } = TimePicker;
+
+export default function dateRange(p) {
+  const { format = 'dateTime' } = p && p.schema;
+  const onChange = (value, string) => p.onChange(string);
+  const RangeComponent = format === 'time' ? TimeRange : DateRange;
+  const hocProps = { ...p, onChange, RangeComponent };
+  return <RangeHoc {...hocProps} />;
+}

--- a/packages/FR1.0/src/widgets/antd/idInput.js
+++ b/packages/FR1.0/src/widgets/antd/idInput.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Input } from 'antd';
+import { getKeyFromUniqueId, changeKeyFromUniqueId } from '../../utils';
+
+export default function IdInput({
+  onChange,
+  value,
+  disabled,
+  readonly,
+  options,
+}) {
+  const handleChange = e => {
+    try {
+      const newId = changeKeyFromUniqueId(value, e.target.value);
+      onChange(newId);
+    } catch (error) {}
+  };
+
+  return (
+    <Input
+      disabled={disabled || readonly}
+      {...options}
+      onChange={handleChange}
+      value={getKeyFromUniqueId(value)}
+    />
+  );
+}

--- a/packages/FR1.0/src/widgets/antd/index.js
+++ b/packages/FR1.0/src/widgets/antd/index.js
@@ -1,0 +1,36 @@
+import checkboxes from './checkboxes';
+import color from './color';
+import date from './date';
+import dateRange from './dateRange';
+import list from './list';
+import map from './map';
+import multiSelect from './multiSelect';
+import radio from './radio';
+import select from './select';
+import slider from './slider';
+import textarea from './textarea';
+import upload from './upload';
+import ImageInput from './ImageInput';
+import { InputNumber, Checkbox, Switch, Input } from 'antd';
+
+export const widgets = {
+  checkbox: Checkbox,
+  checkboxes, // checkbox多选
+  color,
+  date,
+  dateRange,
+  input: Input,
+  imageInput: ImageInput,
+  list,
+  map,
+  multiSelect, // 下拉多选
+  number: InputNumber,
+  radio,
+  select,
+  slider, // 带滚条的number
+  switch: Switch,
+  textarea,
+  upload,
+};
+
+export const defaultWidgetNameList = Object.keys(widgets);

--- a/packages/FR1.0/src/widgets/antd/input.js
+++ b/packages/FR1.0/src/widgets/antd/input.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Input } from 'antd';
+
+export default function input(props) {
+  const { value, onChange, schema, disabled, options } = props;
+  const { format = 'text' } = schema;
+  const type = format;
+  return (
+    <Input
+      size="small"
+      {...options}
+      value={value}
+      type={type}
+      disabled={disabled}
+      onChange={onChange}
+    />
+  );
+}

--- a/packages/FR1.0/src/widgets/antd/list.jsx
+++ b/packages/FR1.0/src/widgets/antd/list.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function map({ children }) {
+  return <div className="w-100">{children}</div>;
+}

--- a/packages/FR1.0/src/widgets/antd/map.js
+++ b/packages/FR1.0/src/widgets/antd/map.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Collapse } from 'antd';
+const { Panel } = Collapse;
+
+export default function map({ children, title }) {
+  if (!title) {
+    return <div className="w-100">{children}</div>;
+  }
+  return (
+    <div className="w-100">
+      <Collapse defaultActiveKey={['1']}>
+        <Panel header={title} key="1" className="fr-collapse-object">
+          {children}
+        </Panel>
+      </Collapse>
+    </div>
+  );
+}
+
+// export default function map({ children, title }) {
+//   return <div className="w-100">{children}</div>;
+// }

--- a/packages/FR1.0/src/widgets/antd/multiSelect.js
+++ b/packages/FR1.0/src/widgets/antd/multiSelect.js
@@ -1,0 +1,9 @@
+/**
+ * Updated by Tw93 on 2019-12-07.
+ * 多选组件
+ */
+
+import { Select } from 'antd';
+import multiSelectHoc from '../../components/multiSelectHoc';
+
+export default multiSelectHoc(Select);

--- a/packages/FR1.0/src/widgets/antd/percentSlider.js
+++ b/packages/FR1.0/src/widgets/antd/percentSlider.js
@@ -1,0 +1,74 @@
+import React from 'react';
+import { InputNumber, Slider } from 'antd';
+
+const PercentSlider = p => {
+  const style = p.invalid ? { borderColor: '#f5222d' } : {};
+  const { max, min, step } = p.schema;
+  let setting = {};
+  if (max || max === 0) {
+    setting = { max };
+  }
+
+  if (min || min === 0) {
+    setting = { ...setting, min };
+  }
+
+  if (step) {
+    setting = { ...setting, step };
+  }
+
+  let hideNumber = false;
+  if (p.options && p.options.hideNumber) {
+    hideNumber = true;
+  }
+
+  const isPercent = string =>
+    typeof string === 'string' && string.endsWith('%');
+
+  let numberValue = 100;
+  if (isPercent(p.value)) {
+    try {
+      numberValue = Number(p.value.split('%')[0]);
+      if (Number.isNaN(numberValue)) numberValue = 100;
+    } catch (error) {}
+  }
+
+  const handleChange = newNumber => {
+    const a = newNumber + '%';
+    p.onChange(a);
+  };
+
+  const renderNumber = p.readonly ? (
+    <span style={{ width: '80px' }}>
+      {p.value === (undefined || '') ? '-' : p.value + '%'}
+    </span>
+  ) : (
+    <InputNumber
+      {...p.options}
+      {...setting}
+      style={{ width: '80px', ...style }}
+      value={numberValue}
+      disabled={p.disabled}
+      onChange={handleChange}
+      formatter={value => `${value}%`}
+      parser={value => value.replace('%', '')}
+    />
+  );
+
+  return (
+    <div className='fr-slider'>
+      <Slider
+        style={{ flexGrow: 1, marginRight: hideNumber ? 0 : 12 }}
+        {...setting}
+        onChange={handleChange}
+        max={100}
+        tipFormatter={v => v + '%'}
+        value={numberValue || 100}
+        disabled={p.disabled || p.readonly}
+      />
+      {hideNumber ? null : renderNumber}
+    </div>
+  );
+};
+
+export default PercentSlider;

--- a/packages/FR1.0/src/widgets/antd/radio.js
+++ b/packages/FR1.0/src/widgets/antd/radio.js
@@ -1,0 +1,14 @@
+/**
+ * Updated by Tw93 on 2019-12-07.
+ * 单选组件
+ */
+import React from 'react';
+import { Radio } from 'antd';
+import RadioHoc from '../../components/radioHoc';
+
+const RadioComponent = p => {
+  const onChange = e => p.onChange(e.target.value);
+  return <RadioHoc {...p} onChange={onChange} Radio={Radio} />;
+};
+
+export default RadioComponent;

--- a/packages/FR1.0/src/widgets/antd/select.js
+++ b/packages/FR1.0/src/widgets/antd/select.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Select } from 'antd';
+import { createWidget } from '../../HOC';
+import { getArray } from '../../utils';
+
+const mapProps = ({ schema, style, ...rest }) => {
+  let options;
+  // 如果已经有外部注入的options了，内部的schema就会被忽略
+  if (rest && rest.options && Array.isArray(rest.options)) {
+    options = rest.options;
+  } else {
+    const { enum: enums, enumNames } = schema || {};
+    options = getArray(enums).map((item, idx) => {
+      let label = enumNames && Array.isArray(enumNames) ? enumNames[idx] : item;
+      const isHtml = typeof label === 'string' && label[0] === '<';
+      if (isHtml) {
+        label = <span dangerouslySetInnerHTML={{ __html: label }} />;
+      }
+      return { label, value: item };
+    });
+  }
+
+  return {
+    options,
+    style: { width: '100%', ...style },
+  };
+};
+
+const A = props => {
+  // if (props.schema.$id === 'allEnum.select') {
+  //   console.log(props, 'selectProps');
+  // }
+  return <Select {...props} />;
+};
+
+const Component = createWidget(mapProps)(A);
+
+export default Component;

--- a/packages/FR1.0/src/widgets/antd/slider.js
+++ b/packages/FR1.0/src/widgets/antd/slider.js
@@ -1,0 +1,59 @@
+/**
+ * Created by Tw93 on 2019-12-07.
+ * 滑动输入组件
+ */
+
+import React from 'react';
+import { InputNumber, Slider } from 'antd';
+
+const SliderWithNumber = p => {
+  const style = p.invalid ? { borderColor: '#f5222d' } : {};
+  const { max, min, step } = p.schema;
+  let setting = {};
+  if (max || max === 0) {
+    setting = { max };
+  }
+
+  if (min || min === 0) {
+    setting = { ...setting, min };
+  }
+
+  if (step) {
+    setting = { ...setting, step };
+  }
+
+  let hideNumber = false;
+  if (p.options && p.options.hideNumber) {
+    hideNumber = true;
+  }
+
+  const renderNumber = p.readonly ? (
+    <span style={{ width: '90px' }}>
+      {p.value === (undefined || '') ? '-' : p.value}
+    </span>
+  ) : (
+    <InputNumber
+      {...p.options}
+      {...setting}
+      style={{ width: '90px', ...style }}
+      value={p.value}
+      disabled={p.disabled}
+      onChange={p.onChange}
+    />
+  );
+
+  return (
+    <div className='fr-slider'>
+      <Slider
+        style={{ flexGrow: 1, marginRight: hideNumber ? 0 : 12 }}
+        {...setting}
+        onChange={p.onChange}
+        value={typeof p.value === 'number' ? p.value : min || 0}
+        disabled={p.disabled || p.readonly}
+      />
+      {hideNumber ? null : renderNumber}
+    </div>
+  );
+};
+
+export default SliderWithNumber;

--- a/packages/FR1.0/src/widgets/antd/textarea.js
+++ b/packages/FR1.0/src/widgets/antd/textarea.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Input } from 'antd';
+
+const { TextArea } = Input;
+
+export default function ta(p) {
+  const { options, invalid } = p;
+  const style = invalid ? { borderColor: '#f5222d' } : {};
+  const defaultUi = { rows: 3 };
+  const ui = { ...defaultUi, ...options };
+  const onChange = (e) => p.onChange(e.target.value);
+  return (
+    <TextArea
+      style={style}
+      disabled={p.disabled || p.readonly}
+      value={p.value}
+      {...ui}
+      onChange={onChange}
+    />
+  );
+}

--- a/packages/FR1.0/src/widgets/antd/upload.js
+++ b/packages/FR1.0/src/widgets/antd/upload.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import { UploadOutlined } from '@ant-design/icons';
+import { Upload, message, Button } from 'antd';
+
+export default function input(p) {
+  const props = {
+    name: 'file',
+    action: p.action,
+    enctype: 'multipart/form-data',
+    withCredentials: true,
+    type: 'file',
+    onChange(info) {
+      if (info.file.status === 'done') {
+        message.success(`${info.file.name} 上传成功`);
+        p.onChange(info.file.response.url);
+      } else if (info.file.status === 'error') {
+        message.error(`${info.file.name} 上传失败`);
+      }
+    },
+    onRemove() {
+      p.onChange('');
+    },
+  };
+
+  return (
+    <div className="fr-upload-mod">
+      <Upload {...props} className="fr-upload-file">
+        <Button>
+          <UploadOutlined /> 上传
+        </Button>
+      </Upload>
+      {p.value && (
+        <a
+          href={p.value}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="fr-upload-preview"
+        >
+          已上传地址
+        </a>
+      )}
+    </div>
+  );
+}

--- a/packages/form-render/.fatherrc.js
+++ b/packages/form-render/.fatherrc.js
@@ -15,7 +15,7 @@ export default {
       {
         libraryName: 'antd',
         libraryDirectory: 'lib',
-        style: 'css',
+        style: true,
       },
       'antd',
     ],

--- a/packages/form-render/CHANGELOG.md
+++ b/packages/form-render/CHANGELOG.md
@@ -1,9 +1,31 @@
 # Change Log
 
-### 0.9.13
+### 0.10.0
+
+- [+] 新增 validator 字段，用于动态校验, 可使用 value、formData 写函数 or 表达式字符串
+
+```js
+{
+  type: 'object',
+  properties: {
+    pwd: {
+      title: '密码',
+      type: 'string',
+      validator: "{{value.length > 6 ? '长度超了': ''}}",
+    },
+    pwd2: {
+      title: '重复输入密码',
+      type: 'string',
+      validator: "{{formData.pwd == value ? '': '两个密码不一致'}}",
+    },
+  },
+}
+```
 
 - [!] fusion 侧 input / textarea 的 props 变更：hasLimitHint -> showLimitHint
-- [!]
+- [!] fix 了内部使用 use-debounce 包在 webpack5 下报错的问题
+
+- [!] fix 了外部触发 formData 更新后不触碰表单直接提交时，default 和选择框初始值消失的问题
 
 ### 0.9.12
 

--- a/packages/form-render/CHANGELOG.md
+++ b/packages/form-render/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+### 0.9.13
+
+- [!] fusion 侧 input / textarea 的 props 变更：hasLimitHint -> showLimitHint
+- [!]
+
 ### 0.9.12
 
 - [!] 修复了 radio 选择框等较窄的展示没有对齐的问题

--- a/packages/form-render/CHANGELOG.md
+++ b/packages/form-render/CHANGELOG.md
@@ -24,7 +24,6 @@
 
 - [!] fusion 侧 input / textarea 的 props 变更：hasLimitHint -> showLimitHint
 - [!] fix 了内部使用 use-debounce 包在 webpack5 下报错的问题
-
 - [!] fix 了外部触发 formData 更新后不触碰表单直接提交时，default 和选择框初始值消失的问题
 
 ### 0.9.12

--- a/packages/form-render/package.json
+++ b/packages/form-render/package.json
@@ -58,7 +58,6 @@
     "prop-types": "^15.x",
     "rc-color-picker": "^1.2.6",
     "react-sortable-hoc": "^1.6.1",
-    "use-debounce": "^5.1.0",
     "validator": "^10.7.1"
   },
   "peerDependencies": {

--- a/packages/form-render/package.json
+++ b/packages/form-render/package.json
@@ -1,6 +1,6 @@
 {
   "name": "form-render",
-  "version": "0.9.12",
+  "version": "0.10.0",
   "description": "通过 JSON Schema 生成标准 Form，常用于自定义搭建配置界面生成",
   "repository": {
     "type": "git",

--- a/packages/form-render/src/base/useDebounce.js
+++ b/packages/form-render/src/base/useDebounce.js
@@ -1,0 +1,167 @@
+import { useRef, useEffect, useMemo } from 'react';
+
+function useDebouncedCallback(func, wait, options) {
+  const lastCallTime = useRef(null);
+  const lastInvokeTime = useRef(0);
+  const timerId = useRef(null);
+  const lastArgs = useRef([]);
+  const lastThis = useRef();
+  const result = useRef();
+  const funcRef = useRef(func);
+  const mounted = useRef(true);
+
+  funcRef.current = func;
+
+  // Bypass `requestAnimationFrame` by explicitly setting `wait=0`.
+  const useRAF = !wait && wait !== 0 && typeof window !== 'undefined';
+
+  if (typeof func !== 'function') {
+    throw new TypeError('Expected a function');
+  }
+
+  wait = +wait || 0;
+  options = options || {};
+
+  const leading = !!options.leading;
+  const trailing = 'trailing' in options ? !!options.trailing : true; // `true` by default
+  const maxing = 'maxWait' in options;
+  const maxWait = maxing ? Math.max(+options.maxWait || 0, wait) : null;
+
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+
+  // You may have a question, why we have so many code under the useMemo definition.
+  //
+  // This was made as we want to escape from useCallback hell and
+  // not to initialize a number of functions each time useDebouncedCallback is called.
+  //
+  // It means that we have less garbage for our GC calls which improves performance.
+  // Also, it makes this library smaller.
+  //
+  // And the last reason, that the code without lots of useCallback with deps is easier to read.
+  // You have only one place for that.
+  const debounced = useMemo(() => {
+    const invokeFunc = time => {
+      const args = lastArgs.current;
+      const thisArg = lastThis.current;
+
+      lastArgs.current = lastThis.current = null;
+      lastInvokeTime.current = time;
+      return (result.current = funcRef.current.apply(thisArg, args));
+    };
+
+    const startTimer = (pendingFunc, wait) => {
+      if (useRAF) cancelAnimationFrame(timerId.current);
+      timerId.current = useRAF
+        ? requestAnimationFrame(pendingFunc)
+        : setTimeout(pendingFunc, wait);
+    };
+
+    const shouldInvoke = time => {
+      if (!mounted.current) return false;
+
+      const timeSinceLastCall = time - lastCallTime.current;
+      const timeSinceLastInvoke = time - lastInvokeTime.current;
+
+      // Either this is the first call, activity has stopped and we're at the
+      // trailing edge, the system time has gone backwards and we're treating
+      // it as the trailing edge, or we've hit the `maxWait` limit.
+      return (
+        !lastCallTime.current ||
+        timeSinceLastCall >= wait ||
+        timeSinceLastCall < 0 ||
+        (maxing && timeSinceLastInvoke >= maxWait)
+      );
+    };
+
+    const trailingEdge = time => {
+      timerId.current = null;
+
+      // Only invoke if we have `lastArgs` which means `func` has been
+      // debounced at least once.
+      if (trailing && lastArgs.current) {
+        return invokeFunc(time);
+      }
+      lastArgs.current = lastThis.current = null;
+      return result.current;
+    };
+
+    const timerExpired = () => {
+      const time = Date.now();
+      if (shouldInvoke(time)) {
+        return trailingEdge(time);
+      }
+      // https://github.com/xnimorz/use-debounce/issues/97
+      if (!mounted.current) {
+        return;
+      }
+      // Remaining wait calculation
+      const timeSinceLastCall = time - lastCallTime.current;
+      const timeSinceLastInvoke = time - lastInvokeTime.current;
+      const timeWaiting = wait - timeSinceLastCall;
+      const remainingWait = maxing
+        ? Math.min(timeWaiting, maxWait - timeSinceLastInvoke)
+        : timeWaiting;
+
+      // Restart the timer
+      startTimer(timerExpired, remainingWait);
+    };
+
+    const func = (...args) => {
+      const time = Date.now();
+      const isInvoking = shouldInvoke(time);
+
+      lastArgs.current = args;
+      lastThis.current = this;
+      lastCallTime.current = time;
+
+      if (isInvoking) {
+        if (!timerId.current && mounted.current) {
+          // Reset any `maxWait` timer.
+          lastInvokeTime.current = lastCallTime.current;
+          // Start the timer for the trailing edge.
+          startTimer(timerExpired, wait);
+          // Invoke the leading edge.
+          return leading ? invokeFunc(lastCallTime.current) : result.current;
+        }
+        if (maxing) {
+          // Handle invocations in a tight loop.
+          startTimer(timerExpired, wait);
+          return invokeFunc(lastCallTime.current);
+        }
+      }
+      if (!timerId.current) {
+        startTimer(timerExpired, wait);
+      }
+      return result.current;
+    };
+
+    func.cancel = () => {
+      if (timerId.current) {
+        useRAF
+          ? cancelAnimationFrame(timerId.current)
+          : clearTimeout(timerId.current);
+      }
+      lastInvokeTime.current = 0;
+      lastArgs.current = lastCallTime.current = lastThis.current = timerId.current = null;
+    };
+
+    func.isPending = () => {
+      return !!timerId.current;
+    };
+
+    func.flush = () => {
+      return !timerId.current ? result.current : trailingEdge(Date.now());
+    };
+
+    return func;
+  }, [leading, maxing, wait, maxWait, trailing, useRAF]);
+
+  return debounced;
+}
+
+export default useDebouncedCallback;

--- a/packages/form-render/src/base/utils.js
+++ b/packages/form-render/src/base/utils.js
@@ -255,6 +255,14 @@ export const evaluateString = (string, formData, rootValue) =>
   return (${string})
   `);
 
+// 解析函数字符串值(用于validator，入参只有value)
+export const evaluateString2 = (string, value, formData) =>
+  safeEval(`
+  const value =${JSON.stringify(value)};
+  const formData = ${JSON.stringify(formData)};
+  return (${string})
+  `);
+
 // 判断schema的值是是否是“函数”
 // JSON无法使用函数值的参数，所以使用"{{...}}"来标记为函数，也可使用@标记，不推荐。
 export function isFunction(func) {
@@ -307,6 +315,23 @@ export const convertValue = (item, formData, rootValue) => {
     const _item = isFunction(item);
     try {
       return evaluateString(_item, formData, rootValue);
+    } catch (error) {
+      console.error(error.message);
+      console.error(`happen at ${item}`);
+      return item;
+    }
+  }
+  return item;
+};
+
+// 用于validator的求值，入参只有value
+export const convertValue2 = (item, value, formData) => {
+  if (typeof item === 'function') {
+    return item(value, formData);
+  } else if (typeof item === 'string' && isFunction(item) !== false) {
+    const _item = isFunction(item);
+    try {
+      return evaluateString2(_item, value, formData);
     } catch (error) {
       console.error(error.message);
       console.error(`happen at ${item}`);

--- a/packages/form-render/src/index.js
+++ b/packages/form-render/src/index.js
@@ -5,7 +5,7 @@ import React, {
   useImperativeHandle,
   useState,
 } from 'react';
-import useDebouncedCallback from 'use-debounce/lib/useDebouncedCallback';
+import useDebouncedCallback from './base/useDebounce';
 import { usePrevious } from './hooks';
 import PropTypes from 'prop-types';
 import { isDeepEqual, combineSchema } from './base/utils';

--- a/packages/form-render/src/index.js
+++ b/packages/form-render/src/index.js
@@ -133,7 +133,7 @@ function FormRender({
     isUserInput.current = true;
     // 开始编辑，节流
     setEditing(true);
-    debouncedSetEditing.callback(false);
+    debouncedSetEditing(false);
     onChange(val);
     onValidate(getValidateList(val, schema));
   };

--- a/packages/form-render/src/index.js
+++ b/packages/form-render/src/index.js
@@ -88,7 +88,10 @@ function FormRender({
   const [isEditing, setEditing] = useState(false);
   const debouncedSetEditing = useDebouncedCallback(setEditing, 300);
 
-  const data = useMemo(() => resolve(schema, formData), [schema, formData]);
+  const data = useMemo(() => resolve(schema, formData), [
+    JSON.stringify(schema),
+    JSON.stringify(formData),
+  ]);
 
   useEffect(() => {
     onChange(data);
@@ -96,21 +99,22 @@ function FormRender({
   }, []);
 
   useEffect(() => {
-    if (isUserInput.current) {
+    if (firstRender.current) {
+      onMount();
+      firstRender.current = false;
+    }
+    updateValidation();
+    if (!isUserInput.current) {
+      onChange(data); // 这个操作不做，当外部修改formData后如果不操作form，返回的值会是没有resolve过的
+    } else {
       isUserInput.current = false;
-      return;
     }
-    if (!isDeepEqual(previousSchema, schema)) {
-      onChange(data);
-      updateValidation();
-    } else if (!isDeepEqual(previousData, formData)) {
-      if (firstRender.current) {
-        onMount();
-        firstRender.current = false;
-      }
-      updateValidation();
-    }
-  }, [schema, formData]);
+  }, [JSON.stringify(formData)]);
+
+  useEffect(() => {
+    onChange(data);
+    updateValidation();
+  }, [JSON.stringify(schema)]);
 
   // data修改比较常用，所以放第一位
   const resetData = (newData, newSchema) => {

--- a/packages/form-render/src/widgets/antd/input.jsx
+++ b/packages/form-render/src/widgets/antd/input.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { PictureOutlined } from '@ant-design/icons';
 import { Input, Popover } from 'antd';
-import useDebouncedCallback from 'use-debounce/lib/useDebouncedCallback';
+import useDebouncedCallback from '../../base/useDebounce';
 import previewContent from '../../components/previewContent';
 
 const PreviewNode = ({ format, value, showPop, setShowPop }) => {

--- a/packages/form-render/src/widgets/antd/input.jsx
+++ b/packages/form-render/src/widgets/antd/input.jsx
@@ -34,7 +34,7 @@ export default function input(p) {
   const handleChange = e => {
     p.onChange(p.name, e.target.value);
     setShowPop(true);
-    debouncedSetShowPop.callback(false);
+    debouncedSetShowPop(false);
   };
 
   let suffix = undefined;

--- a/packages/form-render/src/widgets/fusion/input.jsx
+++ b/packages/form-render/src/widgets/fusion/input.jsx
@@ -31,7 +31,7 @@ export default function input(p) {
   const config = {
     ...rest,
     maxLength,
-    hasLimitHint: maxLength ? true : false,
+    showLimitHint: maxLength ? true : false,
   };
   return (
     <Input

--- a/packages/form-render/src/widgets/fusion/textarea.jsx
+++ b/packages/form-render/src/widgets/fusion/textarea.jsx
@@ -17,7 +17,7 @@ export default function ta(p) {
   const config = {
     ...options,
     maxLength,
-    hasLimitHint: maxLength ? true : false,
+    showLimitHint: maxLength ? true : false,
   };
   return (
     <TextArea

--- a/widgets/RichText/src/index.js
+++ b/widgets/RichText/src/index.js
@@ -34,7 +34,6 @@ const RichTextEditor = ({ name, onChange, value, ...rest }) => {
         onChange={handleChange}
         onSave={onSave}
         onBlur={onSave}
-        onFocus={onSave}
       />
     </div>
   );


### PR DESCRIPTION
### 0.10.0

- [+] 新增 validator 字段，用于动态校验, 可使用 value、formData 写函数 or 表达式字符串

```js
{
  type: 'object',
  properties: {
    pwd: {
      title: '密码',
      type: 'string',
      validator: "{{value.length > 6 ? '长度超了': ''}}",
    },
    pwd2: {
      title: '重复输入密码',
      type: 'string',
      validator: "{{formData.pwd == value ? '': '两个密码不一致'}}",
    },
  },
}
```

- [!] fusion 侧 input / textarea 的 props 变更：hasLimitHint -> showLimitHint
- [!] fix 了内部使用 use-debounce 包在 webpack5 下报错的问题
- [!] fix 了外部触发 formData 更新后不触碰表单直接提交时，default 和选择框初始值消失的问题
